### PR TITLE
Unify enum/optional/match as tagged values (Computation IR 0.2, Phase 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux desktop dependencies
         run: |
@@ -26,6 +29,9 @@ jobs:
             pkg-config
       - run: python3 -m pip install --upgrade pip
       - run: python3 -m pip install -r requirements-dev.txt
+      - name: Install VS Code extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
       - name: Fetch Rust dependencies
         run: |
           for manifest in */Cargo.toml; do

--- a/ReasonRuntime/crates/computation-ir/src/ir.rs
+++ b/ReasonRuntime/crates/computation-ir/src/ir.rs
@@ -1,16 +1,23 @@
-//! Decoder for `reason-computation-ir/0.1` JSON documents, as produced by
+//! Decoder for `reason-computation-ir/0.2` JSON documents, as produced by
 //! `frontend.computation_ir.lowering.lower_program` on the Python side.
 //!
 //! Field names and shapes here must stay in lockstep with
 //! `frontend/computation_ir/schema.py` and `lowering.py` -- this is the
 //! Rust side of the "Python frontend generates canonical JSON, Rust reads
 //! it" transfer rule from the modernization plan (section 6).
+//!
+//! 0.2 adds `enum`, `optional` (`some(...)`/`none`), and `match` as tagged
+//! values with real pattern matching (Phase 1 of the enum/optional/match
+//! unification plan): the `EnumValue`/`OptionalSome`/`OptionalNone` `Expr`
+//! variants, and the `Match` `Terminator` variant together with the
+//! `Pattern` vocabulary consumed by its `arms` -- see `schema.py`'s
+//! `PATTERN_KINDS` for the shared shape.
 
 use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
-pub const SCHEMA: &str = "reason-computation-ir/0.1";
+pub const SCHEMA: &str = "reason-computation-ir/0.2";
 
 #[derive(Debug, Deserialize)]
 pub struct Program {
@@ -95,6 +102,62 @@ pub enum Terminator {
     Return { value: Expr },
     #[serde(rename = "trap")]
     Trap { code: String, message: String },
+    #[serde(rename = "match")]
+    Match { subject: Expr, arms: Vec<MatchArm> },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MatchArm {
+    pub pattern: Pattern,
+    #[serde(default)]
+    pub guard: Option<Expr>,
+    pub target: String,
+}
+
+/// Pattern vocabulary for a `match` terminator's `arms`, mirroring
+/// `schema.py`'s `PATTERN_KINDS` and `lowering.py`'s `_lower_pattern`.
+///
+/// `Wildcard` covers both `_` and `default` (both match unconditionally,
+/// no binding); `Binding` covers both a bare identifier pattern and a
+/// struct shorthand/rename binding (both match unconditionally and bind
+/// `name`). `OptionalSome` always carries a nested `pattern`, unifying
+/// the simple `Some(x)`/`Some(_)` forms and `Some(<nested pattern>)` into
+/// one shape.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind")]
+pub enum Pattern {
+    #[serde(rename = "wildcard")]
+    Wildcard,
+    #[serde(rename = "binding")]
+    Binding { name: String },
+    #[serde(rename = "literal")]
+    Literal {
+        value_kind: String,
+        value: serde_json::Value,
+    },
+    #[serde(rename = "range")]
+    Range {
+        lower: serde_json::Value,
+        upper: serde_json::Value,
+        lower_inclusive: bool,
+        upper_inclusive: bool,
+    },
+    #[serde(rename = "enum_value")]
+    EnumValue {
+        enum_name: String,
+        variant_name: String,
+    },
+    #[serde(rename = "optional_some")]
+    OptionalSome { pattern: Box<Pattern> },
+    #[serde(rename = "optional_none")]
+    OptionalNone,
+    #[serde(rename = "struct")]
+    Struct {
+        type_name: String,
+        fields: BTreeMap<String, Pattern>,
+    },
+    #[serde(rename = "or")]
+    Or { alternatives: Vec<Pattern> },
 }
 
 #[derive(Debug, Deserialize)]
@@ -234,6 +297,24 @@ pub enum Expr {
         #[serde(default)]
         source_span: Option<serde_json::Value>,
     },
+    #[serde(rename = "enum_value")]
+    EnumValue {
+        enum_name: String,
+        variant_name: String,
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
+    #[serde(rename = "optional_some")]
+    OptionalSome {
+        value: Box<Expr>,
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
+    #[serde(rename = "optional_none")]
+    OptionalNone {
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
 }
 
 impl Expr {
@@ -257,7 +338,10 @@ impl Expr {
             | Expr::CallReasoning { source_span, .. }
             | Expr::CallArrayAppend { source_span, .. }
             | Expr::CallFunction { source_span, .. }
-            | Expr::CallCast { source_span, .. } => source_span.as_ref(),
+            | Expr::CallCast { source_span, .. }
+            | Expr::EnumValue { source_span, .. }
+            | Expr::OptionalSome { source_span, .. }
+            | Expr::OptionalNone { source_span, .. } => source_span.as_ref(),
         }
     }
 }

--- a/ReasonRuntime/crates/computation-ir/src/value.rs
+++ b/ReasonRuntime/crates/computation-ir/src/value.rs
@@ -52,6 +52,19 @@ pub enum Value {
     String(Rc<str>),
     Array(Rc<RefCell<Vec<Value>>>),
     Struct(Rc<StructValue>),
+    /// A resolved `EnumName.VariantName` reference (Phase 1 enum
+    /// unification). Distinct from `String` so `Color.Red == "Red"` is a
+    /// type mismatch (falls to `PartialEq`'s catch-all `_ => false`)
+    /// rather than an accidental true.
+    Enum {
+        enum_name: Rc<str>,
+        variant_name: Rc<str>,
+    },
+    /// `some(x)` / `none` (Phase 1 optional unification). Deliberately not
+    /// the same value as `Value::Null`: a `none` is a tagged "absent"
+    /// Optional, so `none == null` is false and a match arm for one can't
+    /// accidentally catch the other.
+    Optional(Option<Box<Value>>),
     Tensor(Rc<str>),
     ReasonObject(Rc<RuntimeReasonObject>),
     ReasonObjectSnapshot(Rc<RuntimeReasonObjectSnapshot>),
@@ -88,6 +101,9 @@ impl Value {
                 ),
             })),
             Value::Json(value) => Value::Json(Rc::new((**value).clone())),
+            Value::Optional(inner) => {
+                Value::Optional(inner.as_deref().map(|value| Box::new(value.deep_clone())))
+            }
             other => other.clone(),
         }
     }
@@ -101,6 +117,8 @@ impl Value {
             Value::String(_) => "String",
             Value::Array(_) => "Array",
             Value::Struct(_) => "Struct",
+            Value::Enum { .. } => "Enum",
+            Value::Optional(_) => "Optional",
             Value::Tensor(_) => "Tensor",
             Value::ReasonObject(_) => "ReasonObject",
             Value::ReasonObjectSnapshot(_) => "ReasonObjectSnapshot",
@@ -122,6 +140,17 @@ impl PartialEq for Value {
             (Value::Struct(a), Value::Struct(b)) => {
                 a.type_name == b.type_name && *a.fields.borrow() == *b.fields.borrow()
             }
+            (
+                Value::Enum {
+                    enum_name: a_enum,
+                    variant_name: a_variant,
+                },
+                Value::Enum {
+                    enum_name: b_enum,
+                    variant_name: b_variant,
+                },
+            ) => a_enum == b_enum && a_variant == b_variant,
+            (Value::Optional(a), Value::Optional(b)) => a == b,
             (Value::Tensor(a), Value::Tensor(b)) => a == b,
             (Value::ReasonObject(a), Value::ReasonObject(b)) => {
                 let a = a.object.borrow();
@@ -155,6 +184,12 @@ impl fmt::Display for Value {
             Value::String(value) => write!(f, "{value}"),
             Value::Array(_) => write!(f, "<array>"),
             Value::Struct(value) => write!(f, "<struct {}>", value.type_name),
+            Value::Enum {
+                enum_name,
+                variant_name,
+            } => write!(f, "{enum_name}.{variant_name}"),
+            Value::Optional(Some(inner)) => write!(f, "Some({inner})"),
+            Value::Optional(None) => write!(f, "None"),
             Value::Tensor(id) => write!(f, "<tensor {id}>"),
             Value::ReasonObject(value) => write!(
                 f,
@@ -201,6 +236,18 @@ pub fn to_json(value: &Value) -> serde_json::Value {
             map.insert("fields".to_string(), serde_json::Value::Object(fields));
             serde_json::Value::Object(map)
         }
+        Value::Enum {
+            enum_name,
+            variant_name,
+        } => serde_json::json!({
+            "enum_name": enum_name.to_string(),
+            "variant_name": variant_name.to_string(),
+        }),
+        Value::Optional(Some(inner)) => serde_json::json!({
+            "optional": "some",
+            "value": to_json(inner),
+        }),
+        Value::Optional(None) => serde_json::json!({ "optional": "none" }),
         Value::Tensor(id) => {
             // A raw Tensor handle has no plain-JSON representation (it's
             // only meaningful against this run's TensorStore); tests that

--- a/ReasonRuntime/crates/computation-ir/src/vm.rs
+++ b/ReasonRuntime/crates/computation-ir/src/vm.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
 
-use crate::ir::{Block, Expr, Function, Instruction, Program, Terminator};
+use crate::ir::{Block, Expr, Function, Instruction, Pattern, Program, Terminator};
 use crate::value::{from_json, to_json, RuntimeReasonObject, StructValue, Value};
 
 #[derive(Debug)]
@@ -422,6 +422,64 @@ impl<'a> Vm<'a> {
                         return Ok(Outcome::NoValue);
                     }
                     return Err(RuntimeError::new(code, message.clone()));
+                }
+                Terminator::Match { subject, arms } => {
+                    let subject_value = self.eval_expr(subject, env, call_depth)?;
+                    let mut matched_target: Option<&str> = None;
+                    for arm in arms {
+                        let Some(bindings) = match_pattern(&arm.pattern, &subject_value) else {
+                            continue;
+                        };
+                        let previous: Vec<(String, Option<Value>)> = {
+                            let mut env_mut = env.borrow_mut();
+                            bindings
+                                .into_iter()
+                                .map(|(name, value)| {
+                                    let old = env_mut.insert(name.clone(), value);
+                                    (name, old)
+                                })
+                                .collect()
+                        };
+                        let guard_ok = match &arm.guard {
+                            None => true,
+                            Some(guard_expr) => {
+                                match self.eval_expr(guard_expr, env, call_depth)? {
+                                    Value::Bool(value) => value,
+                                    other => {
+                                        return Err(RuntimeError::new(
+                                            "IR-EXEC-007",
+                                            format!(
+                                                "match guard must be Bool, got {}",
+                                                other.type_name()
+                                            ),
+                                        ))
+                                    }
+                                }
+                            }
+                        };
+                        if guard_ok {
+                            matched_target = Some(arm.target.as_str());
+                            break;
+                        }
+                        let mut env_mut = env.borrow_mut();
+                        for (name, old_value) in previous {
+                            match old_value {
+                                Some(value) => {
+                                    env_mut.insert(name, value);
+                                }
+                                None => {
+                                    env_mut.remove(&name);
+                                }
+                            }
+                        }
+                    }
+                    let Some(target) = matched_target else {
+                        return Err(RuntimeError::new(
+                            "RT-MATCH-001",
+                            "no match arm satisfied the value",
+                        ));
+                    };
+                    current = self.resolve_block_id(&blocks, target)?;
                 }
             }
         }
@@ -894,6 +952,19 @@ impl<'a> Vm<'a> {
             Expr::CallFunction {
                 name, arguments, ..
             } => self.call_function(name, arguments, env, call_depth),
+            Expr::EnumValue {
+                enum_name,
+                variant_name,
+                ..
+            } => Ok(Value::Enum {
+                enum_name: Rc::from(enum_name.as_str()),
+                variant_name: Rc::from(variant_name.as_str()),
+            }),
+            Expr::OptionalSome { value, .. } => {
+                let inner = self.eval_expr(value, env, call_depth)?;
+                Ok(Value::Optional(Some(Box::new(inner))))
+            }
+            Expr::OptionalNone { .. } => Ok(Value::Optional(None)),
         }
     }
 
@@ -1033,6 +1104,97 @@ fn const_value(kind: &str, value: &serde_json::Value) -> Result<Value, RuntimeEr
             "IR-EXEC-008",
             format!("unknown const kind: {other}"),
         )),
+    }
+}
+
+/// Structurally matches `value` against a `match` terminator arm's
+/// `Pattern`. Returns the bindings a successful match would introduce
+/// (possibly empty), or `None` if `pattern` does not match `value`.
+/// Mirrors `_match_pattern_json` in `frontend/computation_ir/interpreter.py`
+/// -- the two must agree on every pattern kind for the Python-vs-Rust
+/// parity gate (`test_computation_ir_rust_parity.py`) to hold. Language
+/// surface validation already guarantees a `match` statement is
+/// exhaustive before this IR is ever produced, so a fully-exhausted arm
+/// list (the `RT-MATCH-001` case in the caller) is a defensive fallback,
+/// not an expected outcome.
+fn match_pattern(pattern: &Pattern, value: &Value) -> Option<Vec<(String, Value)>> {
+    match pattern {
+        Pattern::Wildcard => Some(Vec::new()),
+        Pattern::Binding { name } => Some(vec![(name.clone(), value.clone())]),
+        Pattern::Literal { value_kind, value: literal } => {
+            let literal_value = const_value(value_kind, literal).ok()?;
+            if &literal_value == value {
+                Some(Vec::new())
+            } else {
+                None
+            }
+        }
+        Pattern::Range {
+            lower,
+            upper,
+            lower_inclusive,
+            upper_inclusive,
+        } => {
+            let subject = match value {
+                Value::Int(v) => *v as f64,
+                Value::Float(v) => *v,
+                _ => return None,
+            };
+            let lower = lower.as_f64()?;
+            let upper = upper.as_f64()?;
+            let lower_ok = if *lower_inclusive {
+                subject >= lower
+            } else {
+                subject > lower
+            };
+            let upper_ok = if *upper_inclusive {
+                subject <= upper
+            } else {
+                subject < upper
+            };
+            if lower_ok && upper_ok {
+                Some(Vec::new())
+            } else {
+                None
+            }
+        }
+        Pattern::EnumValue {
+            enum_name,
+            variant_name,
+        } => match value {
+            Value::Enum {
+                enum_name: value_enum,
+                variant_name: value_variant,
+            } if value_enum.as_ref() == enum_name.as_str()
+                && value_variant.as_ref() == variant_name.as_str() =>
+            {
+                Some(Vec::new())
+            }
+            _ => None,
+        },
+        Pattern::OptionalSome { pattern } => match value {
+            Value::Optional(Some(inner)) => match_pattern(pattern, inner),
+            _ => None,
+        },
+        Pattern::OptionalNone => match value {
+            Value::Optional(None) => Some(Vec::new()),
+            _ => None,
+        },
+        Pattern::Struct { type_name, fields } => match value {
+            Value::Struct(struct_value) if &struct_value.type_name == type_name => {
+                let mut bindings = Vec::new();
+                let struct_fields = struct_value.fields.borrow();
+                for (field_name, field_pattern) in fields {
+                    let field_value = struct_fields.get(field_name)?;
+                    bindings.extend(match_pattern(field_pattern, field_value)?);
+                }
+                Some(bindings)
+            }
+            _ => None,
+        },
+        Pattern::Or { alternatives } => {
+            alternatives.iter().find_map(|alternative| match_pattern(alternative, value))
+        }
     }
 }
 
@@ -1511,5 +1673,239 @@ mod tests {
             }
             other => panic!("expected an array, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn enum_values_compare_by_name_not_by_string() {
+        assert_eq!(
+            Value::Enum {
+                enum_name: Rc::from("Color"),
+                variant_name: Rc::from("Red")
+            },
+            Value::Enum {
+                enum_name: Rc::from("Color"),
+                variant_name: Rc::from("Red")
+            }
+        );
+        assert_ne!(
+            Value::Enum {
+                enum_name: Rc::from("Color"),
+                variant_name: Rc::from("Red")
+            },
+            Value::Enum {
+                enum_name: Rc::from("Color"),
+                variant_name: Rc::from("Blue")
+            }
+        );
+        assert_ne!(
+            Value::Enum {
+                enum_name: Rc::from("Color"),
+                variant_name: Rc::from("Red")
+            },
+            Value::String(Rc::from("Red"))
+        );
+    }
+
+    #[test]
+    fn match_dispatches_on_enum_value_falling_through_to_wildcard() {
+        let ir = r#"{
+            "schema": "reason-computation-ir/0.2",
+            "calculations": ["Answer"],
+            "functions": [{
+                "id": "Answer",
+                "parameters": [],
+                "entry_block": "b1",
+                "blocks": [
+                    {
+                        "id": "b1",
+                        "instructions": [{
+                            "op": "assign", "target": "color",
+                            "expr": {"op": "enum_value", "enum_name": "Color", "variant_name": "Green"}
+                        }],
+                        "terminator": {
+                            "kind": "match",
+                            "subject": {"op": "local", "name": "color"},
+                            "arms": [
+                                {
+                                    "pattern": {"kind": "enum_value", "enum_name": "Color", "variant_name": "Red"},
+                                    "guard": null,
+                                    "target": "b_red"
+                                },
+                                {
+                                    "pattern": {"kind": "wildcard"},
+                                    "guard": null,
+                                    "target": "b_default"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "b_red",
+                        "instructions": [],
+                        "terminator": {"kind": "result", "value": {"op": "const", "kind": "int", "value": 1}}
+                    },
+                    {
+                        "id": "b_default",
+                        "instructions": [],
+                        "terminator": {"kind": "result", "value": {"op": "const", "kind": "int", "value": 0}}
+                    }
+                ]
+            }]
+        }"#;
+        let results = run(ir).expect("no runtime error");
+        assert_eq!(results, vec![("Answer".to_string(), Value::Int(0))]);
+    }
+
+    #[test]
+    fn match_binds_optional_some_and_distinguishes_none_from_null() {
+        let ir = r#"{
+            "schema": "reason-computation-ir/0.2",
+            "calculations": ["Some", "None"],
+            "functions": [
+                {
+                    "id": "Some",
+                    "parameters": [],
+                    "entry_block": "b1",
+                    "blocks": [
+                        {
+                            "id": "b1",
+                            "instructions": [{
+                                "op": "assign", "target": "value",
+                                "expr": {"op": "optional_some", "value": {"op": "const", "kind": "int", "value": 42}}
+                            }],
+                            "terminator": {
+                                "kind": "match",
+                                "subject": {"op": "local", "name": "value"},
+                                "arms": [
+                                    {
+                                        "pattern": {"kind": "optional_some", "pattern": {"kind": "binding", "name": "x"}},
+                                        "guard": null,
+                                        "target": "b_some"
+                                    },
+                                    {
+                                        "pattern": {"kind": "optional_none"},
+                                        "guard": null,
+                                        "target": "b_none"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "b_some",
+                            "instructions": [],
+                            "terminator": {"kind": "result", "value": {"op": "local", "name": "x"}}
+                        },
+                        {
+                            "id": "b_none",
+                            "instructions": [],
+                            "terminator": {"kind": "result", "value": {"op": "const", "kind": "int", "value": -1}}
+                        }
+                    ]
+                },
+                {
+                    "id": "None",
+                    "parameters": [],
+                    "entry_block": "b1",
+                    "blocks": [
+                        {
+                            "id": "b1",
+                            "instructions": [{
+                                "op": "assign", "target": "value",
+                                "expr": {"op": "optional_none"}
+                            }],
+                            "terminator": {
+                                "kind": "match",
+                                "subject": {"op": "local", "name": "value"},
+                                "arms": [
+                                    {
+                                        "pattern": {"kind": "optional_some", "pattern": {"kind": "binding", "name": "x"}},
+                                        "guard": null,
+                                        "target": "b_some"
+                                    },
+                                    {
+                                        "pattern": {"kind": "optional_none"},
+                                        "guard": null,
+                                        "target": "b_none"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "b_some",
+                            "instructions": [],
+                            "terminator": {"kind": "result", "value": {"op": "local", "name": "x"}}
+                        },
+                        {
+                            "id": "b_none",
+                            "instructions": [],
+                            "terminator": {"kind": "result", "value": {"op": "const", "kind": "int", "value": -1}}
+                        }
+                    ]
+                }
+            ]
+        }"#;
+        let results = run(ir).expect("no runtime error");
+        assert_eq!(
+            results,
+            vec![
+                ("Some".to_string(), Value::Int(42)),
+                ("None".to_string(), Value::Int(-1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn match_guard_failure_rolls_back_pattern_bindings_before_trying_next_arm() {
+        // Both arms bind the subject to `x`; the first arm's guard is
+        // false, so its binding must be undone before the second arm's
+        // guard runs -- otherwise a stale `x` from the failed first arm
+        // could leak into the second arm's guard evaluation.
+        let ir = r#"{
+            "schema": "reason-computation-ir/0.2",
+            "calculations": ["Answer"],
+            "functions": [{
+                "id": "Answer",
+                "parameters": [],
+                "entry_block": "b1",
+                "blocks": [
+                    {
+                        "id": "b1",
+                        "instructions": [],
+                        "terminator": {
+                            "kind": "match",
+                            "subject": {"op": "const", "kind": "int", "value": 5},
+                            "arms": [
+                                {
+                                    "pattern": {"kind": "binding", "name": "x"},
+                                    "guard": {
+                                        "op": "comparison", "operator": "GreaterThan",
+                                        "left": {"op": "local", "name": "x"},
+                                        "right": {"op": "const", "kind": "int", "value": 10}
+                                    },
+                                    "target": "b_big"
+                                },
+                                {
+                                    "pattern": {"kind": "binding", "name": "x"},
+                                    "guard": null,
+                                    "target": "b_default"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "b_big",
+                        "instructions": [],
+                        "terminator": {"kind": "result", "value": {"op": "const", "kind": "int", "value": 1}}
+                    },
+                    {
+                        "id": "b_default",
+                        "instructions": [],
+                        "terminator": {"kind": "result", "value": {"op": "local", "name": "x"}}
+                    }
+                ]
+            }]
+        }"#;
+        let results = run(ir).expect("no runtime error");
+        assert_eq!(results, vec![("Answer".to_string(), Value::Int(5))]);
     }
 }

--- a/computation_ir_tests/test_computation_ir_differential.py
+++ b/computation_ir_tests/test_computation_ir_differential.py
@@ -249,6 +249,219 @@ class TensorInteropTests(unittest.TestCase):
         self.assertEqual(outcome.calculations["Answer"], [4.0])
 
 
+class EnumOptionalMatchTests(unittest.TestCase):
+    """Phase 1: enum/optional/match as tagged values with real pattern matching.
+
+    Each case lowers to a `match` terminator plus (where relevant)
+    `enum_value`/`optional_some`/`optional_none` expression ops (schema
+    0.2) and is executed by both the AST oracle and the IR interpreter,
+    the same differential-testing contract as every other class in this
+    module.
+    """
+
+    def test_enum_match_falls_through_to_default(self):
+        outcome = assert_same_outcome(
+            """module M {
+  enum Color {
+    Red
+    Blue
+    Green
+  }
+
+  fn Score(color: Color) -> int {
+    match color {
+      Color.Red => return 1
+      Color.Blue => return 2
+      default => return 0
+    }
+  }
+
+  calculation Answer {
+    result = Score(Color.Green)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 0)
+
+    def test_enum_match_selects_matching_variant(self):
+        outcome = assert_same_outcome(
+            """module M {
+  enum Color {
+    Red
+    Blue
+    Green
+  }
+
+  fn Score(color: Color) -> int {
+    match color {
+      Color.Red => return 1
+      Color.Blue => return 2
+      default => return 0
+    }
+  }
+
+  calculation Answer {
+    result = Score(Color.Blue)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 2)
+
+    def test_optional_some_and_none_are_distinguished_from_null(self):
+        outcome = assert_same_outcome(
+            """module M {
+  fn Describe(value: optional<int>) -> int {
+    match value {
+      some(x) => return x
+      none => return -1
+    }
+  }
+
+  calculation Answer {
+    let a = Describe(some(42))
+    let b = Describe(none)
+    result = a + b
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 41)
+
+    def test_none_pattern_does_not_match_a_none_value_through_null(self):
+        # `none` (an absent Optional) must stay distinct from `null`
+        # internally -- if the IR interpreter ever collapsed the two the
+        # way the pre-0.2 schema did, `some(x)`/`none` matching would
+        # misbehave the moment a `null` leaked into an Optional slot.
+        outcome = assert_same_outcome(
+            """module M {
+  fn Describe(value: optional<int>) -> int {
+    match value {
+      some(x) => return x
+      none => return -1
+    }
+  }
+
+  calculation Answer {
+    let a: optional<int> = none
+    result = Describe(a)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], -1)
+
+    def test_guard_with_struct_pattern_binding(self):
+        outcome = assert_same_outcome(
+            """module M {
+  struct Point {
+    x: int
+    y: int
+  }
+
+  fn Classify(p: Point) -> int {
+    match p {
+      Point { x, y } when x > y => return 1
+      Point { x, y } when x == y => return 0
+      default => return -1
+    }
+  }
+
+  calculation Answer {
+    let p = Point { x: 5, y: 2 }
+    result = Classify(p)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 1)
+
+    def test_struct_pattern_binds_fields(self):
+        outcome = assert_same_outcome(
+            """module M {
+  struct Point {
+    x: int
+    y: int
+  }
+
+  fn Sum(p: Point) -> int {
+    match p {
+      Point { x, y } => return x + y
+    }
+  }
+
+  calculation Answer {
+    let p = Point { x: 3, y: 4 }
+    result = Sum(p)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 7)
+
+    def test_or_pattern_matches_any_alternative(self):
+        outcome = assert_same_outcome(
+            """module M {
+  fn IsWeekend(n: int) -> bool {
+    match n {
+      0 | 6 => return true
+      default => return false
+    }
+  }
+
+  calculation Answer {
+    result = IsWeekend(6)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], True)
+
+    def test_range_pattern_matches_inclusive_bounds(self):
+        outcome = assert_same_outcome(
+            """module M {
+  fn Grade(score: int) -> int {
+    match score {
+      90..100 => return 1
+      0..89 => return 0
+      default => return -1
+    }
+  }
+
+  calculation Answer {
+    result = Grade(95)
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 1)
+
+    def test_nested_optional_enum_pattern(self):
+        outcome = assert_same_outcome(
+            """module M {
+  enum Color {
+    Red
+    Blue
+  }
+
+  fn Describe(value: optional<Color>) -> int {
+    match value {
+      some(Color.Red) => return 1
+      some(Color.Blue) => return 2
+      none => return 0
+    }
+  }
+
+  calculation Answer {
+    result = Describe(some(Color.Blue))
+  }
+}
+"""
+        )
+        self.assertEqual(outcome.calculations["Answer"], 2)
+
+
 class LoweringScopeErrorTests(unittest.TestCase):
     def test_break_outside_loop_is_rejected_at_lowering(self):
         program = parse(
@@ -264,7 +477,7 @@ class LoweringScopeErrorTests(unittest.TestCase):
         # parser (language-level validation already forbids it), so this
         # asserts lowering doesn't regress on the common path instead.
         ir = lower_program(program)
-        self.assertEqual(ir["schema"], "reason-computation-ir/0.1")
+        self.assertEqual(ir["schema"], "reason-computation-ir/0.2")
         self.assertEqual(ir["calculations"], ["Answer"])
 
 

--- a/computation_ir_tests/test_computation_ir_optimizer.py
+++ b/computation_ir_tests/test_computation_ir_optimizer.py
@@ -620,6 +620,135 @@ class RelationFunctionsInteractionTests(OptimizerParityMixin, unittest.TestCase)
         self.assertEqual(len(filter_calls), 2)
 
 
+class MatchOptimizationTests(OptimizerParityMixin, unittest.TestCase):
+    """Phase 1: the `match` terminator and `enum_value`/`optional_some`/
+    `optional_none` expressions must survive every optimizer pass intact.
+
+    `match` arm blocks are only reachable via a terminator's `arms[].target`
+    list, not `jump`/`branch`'s `target`/`then`/`else` -- unreachable-block
+    removal, predecessor computation, and loop-region detection all needed
+    dedicated `match` handling (`_terminator_targets`) or they would treat
+    every arm block as unreachable and delete it out from under the
+    `match` terminator that still references it.
+    """
+
+    def test_enum_match_survives_unreachable_block_removal(self):
+        # Each arm assigns and falls through to the match's merge block
+        # (rather than every arm unconditionally `return`ing) so the merge
+        # block itself stays reachable -- an all-`return` match/if's merge
+        # block is *already*, pre-existing-ly, reported unreachable by
+        # `validate_program` (the same is true of `_lower_if`, unrelated
+        # to Phase 1); that's a separate, narrower lowering quirk this
+        # test isn't about, so it's avoided here rather than masked.
+        optimized, results = self.assert_parity(
+            """
+            module M {
+                enum Color {
+                    Red
+                    Blue
+                    Green
+                }
+
+                calculation Answer {
+                    let color = Color.Blue
+                    let score = 0
+                    match color {
+                        Color.Red => {
+                            score = 1
+                        }
+                        Color.Blue => {
+                            score = 2
+                        }
+                        default => {
+                            score = 0
+                        }
+                    }
+                    result = score
+                }
+            }
+            """
+        )
+        self.assertEqual(results["Answer"], 2)
+        answer_fn = next(f for f in optimized["functions"] if f["id"] == "Answer")
+        block_ids = {block["id"] for block in answer_fn["blocks"]}
+        match_terminators = [
+            block["terminator"]
+            for block in answer_fn["blocks"]
+            if block["terminator"]["kind"] == "match"
+        ]
+        self.assertEqual(len(match_terminators), 1)
+        for arm in match_terminators[0]["arms"]:
+            self.assertIn(arm["target"], block_ids)
+
+    def test_optional_some_binding_is_not_treated_as_dead_by_local_elimination(self):
+        # `y` is read only inside the match `subject` -- `_eliminate_dead_locals`
+        # must see that read (via the match terminator's `subject`, not
+        # `condition`/`value`) or it would drop `let y = some(5)` and the
+        # match dispatch would fail against an undefined local.
+        optimized, results = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let y = some(5)
+                    let outcome = -1
+                    match y {
+                        some(x) => {
+                            outcome = x
+                        }
+                        none => {
+                            outcome = -1
+                        }
+                    }
+                    result = outcome
+                }
+            }
+            """
+        )
+        self.assertEqual(results["Answer"], 5)
+        answer_fn = next(f for f in optimized["functions"] if f["id"] == "Answer")
+        assigns = [
+            instruction
+            for block in answer_fn["blocks"]
+            for instruction in block["instructions"]
+            if instruction.get("op") == "assign" and instruction.get("target") == "y"
+        ]
+        self.assertEqual(len(assigns), 1)
+
+    def test_match_inside_while_loop_does_not_corrupt_licm(self):
+        # A mutation that happens only inside a match arm (`total` here)
+        # must still count as "mutated within the loop" for LICM's
+        # hoisting-eligibility check -- otherwise `_loop_region`'s
+        # traversal silently stopping at the `match` terminator could let
+        # LICM hoist something that reads a value the loop actually
+        # changes underneath it.
+        optimized, results = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let total = 0
+                    let i = 0
+                    while i < 5 {
+                        match i {
+                            0 | 2 | 4 => {
+                                let step = total + i
+                                total = step
+                            }
+                            default => {
+                                let step = total
+                                total = step
+                            }
+                        }
+                        i = i + 1
+                    }
+                    result = total
+                }
+            }
+            """
+        )
+        self.assertEqual(results["Answer"], 6)
+        del optimized
+
+
 class TensorDifferentialTests(OptimizerParityMixin, unittest.TestCase):
     def test_matmul_program_survives_optimization(self):
         self.assert_parity(

--- a/computation_ir_tests/test_computation_ir_rust_parity.py
+++ b/computation_ir_tests/test_computation_ir_rust_parity.py
@@ -189,6 +189,119 @@ module Main {
         )
         self.assertEqual(results["Answer"], 3)
 
+    def test_enum_match_selects_matching_variant(self):
+        results = self.assert_parity(
+            """module M {
+  enum Color {
+    Red
+    Blue
+    Green
+  }
+
+  fn Score(color: Color) -> int {
+    match color {
+      Color.Red => return 1
+      Color.Blue => return 2
+      default => return 0
+    }
+  }
+
+  calculation Answer {
+    result = Score(Color.Blue)
+  }
+}
+"""
+        )
+        self.assertEqual(results["Answer"], 2)
+
+    def test_optional_some_and_none_are_distinguished_from_null(self):
+        results = self.assert_parity(
+            """module M {
+  fn Describe(value: optional<int>) -> int {
+    match value {
+      some(x) => return x
+      none => return -1
+    }
+  }
+
+  calculation Answer {
+    let a = Describe(some(42))
+    let b = Describe(none)
+    result = a + b
+  }
+}
+"""
+        )
+        self.assertEqual(results["Answer"], 41)
+
+    def test_guard_with_struct_pattern_binding(self):
+        results = self.assert_parity(
+            """module M {
+  struct Point {
+    x: int
+    y: int
+  }
+
+  fn Classify(p: Point) -> int {
+    match p {
+      Point { x, y } when x > y => return 1
+      Point { x, y } when x == y => return 0
+      default => return -1
+    }
+  }
+
+  calculation Answer {
+    let p = Point { x: 5, y: 2 }
+    result = Classify(p)
+  }
+}
+"""
+        )
+        self.assertEqual(results["Answer"], 1)
+
+    def test_or_pattern_and_range_pattern(self):
+        results = self.assert_parity(
+            """module M {
+  fn Grade(score: int) -> int {
+    match score {
+      90..100 => return 1
+      0..89 => return 0
+      default => return -1
+    }
+  }
+
+  calculation Answer {
+    result = Grade(95)
+  }
+}
+"""
+        )
+        self.assertEqual(results["Answer"], 1)
+
+    def test_nested_optional_enum_pattern(self):
+        results = self.assert_parity(
+            """module M {
+  enum Color {
+    Red
+    Blue
+  }
+
+  fn Describe(value: optional<Color>) -> int {
+    match value {
+      some(Color.Red) => return 1
+      some(Color.Blue) => return 2
+      none => return 0
+    }
+  }
+
+  calculation Answer {
+    result = Describe(some(Color.Blue))
+  }
+}
+"""
+        )
+        self.assertEqual(results["Answer"], 2)
+
     def test_softmax_is_implemented_by_the_rust_vm(self):
         source = """module M {
   calculation Answer {

--- a/frontend/computation_ir/interpreter.py
+++ b/frontend/computation_ir/interpreter.py
@@ -25,6 +25,8 @@ from frontend.integrated_computation_runtime import (
     IntegratedComputationResult,
     IntegratedRuntimeError,
     LoopLimitError,
+    RuntimeEnumValue,
+    RuntimeOptionalValue,
     RuntimeStruct,
     _index_value,
     _trace_env,
@@ -161,6 +163,9 @@ def _run_function(function_ir: dict[str, Any], env: dict[str, Any], ctx: _Contex
             if terminator["code"] == "IR-NO-VALUE":
                 raise _IRNoValue()
             raise IRExecutionError(terminator["code"], terminator["message"])
+        if kind == "match":
+            current = _match_dispatch(terminator, env, ctx, call_depth)
+            continue
         raise IRExecutionError("IR-EXEC-001", f"unknown terminator kind: {kind}")
 
 
@@ -216,6 +221,84 @@ def _execute_instruction(instruction: dict[str, Any], env: dict[str, Any], ctx: 
         owner.fields[member] = new_value
         return
     raise IRExecutionError("IR-EXEC-002", f"unknown instruction op: {op}")
+
+
+def _match_dispatch(terminator: dict[str, Any], env: dict[str, Any], ctx: _Context, call_depth: int) -> str:
+    """Executes a `match` terminator: returns the block id execution continues at.
+
+    Mirrors `_match_statement` in `frontend.integrated_computation_runtime`
+    (the AST oracle), but matches against the JSON `Pattern` shape
+    `lowering.py._lower_pattern` produces rather than AST `Pattern` nodes.
+    """
+    subject = _eval_expr(terminator["subject"], env, ctx, call_depth)
+    for arm in terminator["arms"]:
+        bindings = _match_pattern_json(arm["pattern"], subject)
+        if bindings is None:
+            continue
+        previous: list[tuple[str, Any, bool]] = [
+            (name, env.get(name), name in env) for name in bindings
+        ]
+        env.update(bindings)
+        guard = arm.get("guard")
+        guard_ok = guard is None or bool(_eval_expr(guard, env, ctx, call_depth))
+        if guard_ok:
+            return arm["target"]
+        for name, old_value, existed in previous:
+            if existed:
+                env[name] = old_value
+            else:
+                del env[name]
+    raise IntegratedRuntimeError("RT-MATCH-001", "no match arm satisfied the value")
+
+
+def _match_pattern_json(pattern: dict[str, Any], value: Any) -> dict[str, Any] | None:
+    kind = pattern["kind"]
+    if kind == "wildcard":
+        return {}
+    if kind == "binding":
+        return {pattern["name"]: value}
+    if kind == "literal":
+        literal_value = pattern["value"] if pattern["value_kind"] != "null" else None
+        return {} if value == literal_value else None
+    if kind == "range":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        lower, upper = pattern["lower"], pattern["upper"]
+        lower_ok = value >= lower if pattern["lower_inclusive"] else value > lower
+        upper_ok = value <= upper if pattern["upper_inclusive"] else value < upper
+        return {} if lower_ok and upper_ok else None
+    if kind == "enum_value":
+        matches = (
+            isinstance(value, RuntimeEnumValue)
+            and value.enum_name == pattern["enum_name"]
+            and value.variant_name == pattern["variant_name"]
+        )
+        return {} if matches else None
+    if kind == "optional_some":
+        if not isinstance(value, RuntimeOptionalValue) or not value.has_value:
+            return None
+        return _match_pattern_json(pattern["pattern"], value.value)
+    if kind == "optional_none":
+        return {} if isinstance(value, RuntimeOptionalValue) and not value.has_value else None
+    if kind == "struct":
+        if not isinstance(value, RuntimeStruct) or value.type_name != pattern["type_name"]:
+            return None
+        bindings: dict[str, Any] = {}
+        for field_name, field_pattern in pattern["fields"].items():
+            if field_name not in value.fields:
+                return None
+            sub_bindings = _match_pattern_json(field_pattern, value.fields[field_name])
+            if sub_bindings is None:
+                return None
+            bindings.update(sub_bindings)
+        return bindings
+    if kind == "or":
+        for alternative in pattern["alternatives"]:
+            alternative_bindings = _match_pattern_json(alternative, value)
+            if alternative_bindings is not None:
+                return alternative_bindings
+        return None
+    raise IRExecutionError("IR-EXEC-010", f"unknown pattern kind: {kind}")
 
 
 def _visible_trace_env(env: dict[str, Any]) -> dict[str, Any]:
@@ -339,6 +422,12 @@ def _eval_expr(node: dict[str, Any], env: dict[str, Any], ctx: _Context, call_de
         return float(argument) if node["name"] == "float" else int(argument)
     if op == "call_function":
         return _call_function(node["name"], node["arguments"], env, ctx, call_depth)
+    if op == "enum_value":
+        return RuntimeEnumValue(node["enum_name"], node["variant_name"])
+    if op == "optional_some":
+        return RuntimeOptionalValue(True, _eval_expr(node["value"], env, ctx, call_depth))
+    if op == "optional_none":
+        return RuntimeOptionalValue(False)
     raise IRExecutionError("IR-EXEC-003", f"unknown expression op: {op}")
 
 

--- a/frontend/computation_ir/lowering.py
+++ b/frontend/computation_ir/lowering.py
@@ -1,13 +1,13 @@
-"""AST -> reason-computation-ir/0.1 basic-block lowering.
+"""AST -> reason-computation-ir/0.2 basic-block lowering.
 
 Implements the Phase 2 "AST→basic block lowering" item from the
-ReasonScript modernization plan. Scope is bounded to exactly what
+ReasonScript modernization plan, plus the Phase 1 enum/optional/match
+unification (schema 0.2). Scope is bounded to exactly what
 `frontend.integrated_computation_runtime` (the existing AST evaluator)
 supports, since that is the oracle this IR is differentially tested
 against (`frontend.computation_ir.differential`); constructs it doesn't
-handle (pattern matching, Optional/Some, map/set literals and reason_object
-graph queries)
-raise `LoweringError` rather than being silently mishandled.
+handle (map/set literals and reason_object graph queries) raise
+`LoweringError` rather than being silently mishandled.
 """
 
 from __future__ import annotations
@@ -26,6 +26,10 @@ from frontend.language_surface.nodes import (
     ComparisonExpressionNode,
     ConstStatementNode,
     ContinueStatementNode,
+    DefaultPatternNode,
+    EnumDeclarationNode,
+    EnumValuePatternNode,
+    EnumVariantReferenceNode,
     ExpressionNode,
     ExpressionStatementNode,
     FieldAssignmentStatementNode,
@@ -34,32 +38,44 @@ from frontend.language_surface.nodes import (
     FunctionDeclarationNode,
     GoalNode,
     IdentifierNode,
+    IdentifierPatternNode,
     IfStatementNode,
     IndexAccessNode,
     IndexAssignmentStatementNode,
     IntegerLiteralNode,
     LetStatementNode,
+    LiteralPatternNode,
     LogicalExpressionNode,
     LoopStatementNode,
+    MatchStatementNode,
     MemberAccessNode,
     NoneLiteralNode,
     NullLiteralNode,
+    OptionalPatternNode,
+    OptionalValuePatternNode,
+    OrPatternNode,
     ParenthesizedExpressionNode,
     ProgramNode,
     QualifiedIdentifierNode,
+    QualifiedPatternNode,
+    RangePatternNode,
     ReasonGraphDeclarationNode,
     ResultStatementNode,
     ReasonObjectBindingNode,
     ReturnStatementNode,
     RuntimeCallExpressionNode,
     RuntimeCallKind,
+    SomeExpressionNode,
     StateDeclarationNode,
     ConstraintNode,
     ExecutionPlanDeclarationNode,
     StringLiteralNode,
+    StructBindingPatternNode,
     StructLiteralNode,
+    StructPatternNode,
     UnaryExpressionNode,
     WhileStatementNode,
+    WildcardPatternNode,
 )
 from frontend.relation.integration import relation_call_name
 from frontend.tensor.integration import tensor_call_name
@@ -77,6 +93,24 @@ class LoweringError(ValueError):
         super().__init__(f"{code}: {message}")
 
 
+@dataclass(frozen=True)
+class _Scope:
+    """Compile-time name resolution passed down to every `_lower_expression` call.
+
+    `functions` mirrors `integrated_computation_runtime.py`'s per-module
+    `functions` dict (unqualified name -> canonical id, rebuilt per
+    module so a local `fn float`/`fn int` can shadow the builtin cast).
+    `enums` is flat and program-wide (enum names aren't module-qualified
+    anywhere else in this runtime either, e.g. `StructLiteralNode.type_name`)
+    -- it's how `_lower_expression` tells `Color.Red` (an enum variant
+    reference) apart from `point.x` (a struct field access), both of which
+    parse to the same `MemberAccessNode` shape.
+    """
+
+    functions: dict[str, str]
+    enums: dict[str, frozenset[str]]
+
+
 def lower_program(program: ProgramNode) -> dict[str, Any]:
     """Lower every function and calculation in every module to IR Functions.
 
@@ -90,6 +124,17 @@ def lower_program(program: ProgramNode) -> dict[str, Any]:
     reason_object_bindings: list[dict[str, Any]] = []
     reasoning_bindings: dict[str, str] = {}
     package_name = program.package.name if program.package is not None else None
+    # Flat and program-wide (not per-module, unlike `declared_function_names`
+    # below): mirrors how `RuntimeStruct.type_name`/`StructLiteralNode.type_name`
+    # already treat declared type names as a single global namespace, so
+    # `Color.Red` resolves the same way regardless of which module
+    # references it.
+    declared_enums: dict[str, frozenset[str]] = {
+        item.name: frozenset(value.name for value in item.values)
+        for module in program.modules
+        for item in module.body
+        if isinstance(item, EnumDeclarationNode)
+    }
     for module in program.modules:
         reason_object_bindings.extend({
             "name": item.name,
@@ -119,19 +164,20 @@ def lower_program(program: ProgramNode) -> dict[str, Any]:
             item.name: f"{module_namespace}::{item.name}"
             for item in declared_function_nodes
         }
+        scope = _Scope(declared_function_names, declared_enums)
         for item in declared_function_nodes:
             functions.append(
                 _lower_function(
                     f"fn.{declared_function_names[item.name]}",
                     item.parameters,
                     item.body,
-                    declared_function_names,
+                    scope,
                 )
             )
         for item in module.body:
             if isinstance(item, CalculationNode):
                 functions.append(
-                    _lower_function(item.name, (), item.body, declared_function_names)
+                    _lower_function(item.name, (), item.body, scope)
                 )
                 calculation_ids.append(item.name)
     return {
@@ -149,7 +195,7 @@ def _lower_function(
     function_id: str,
     parameters: tuple[Any, ...],
     body: tuple[Any, ...],
-    declared_functions: dict[str, str],
+    scope: _Scope,
 ) -> dict[str, Any]:
     trace_scope = (
         f"fn.{function_id.rsplit('::', 1)[-1]}"
@@ -158,7 +204,7 @@ def _lower_function(
     )
     builder = _BlockBuilder(
         function_id,
-        declared_functions=declared_functions,
+        declared_functions=scope,
         trace_scope=trace_scope,
     )
     entry = builder.new_block("entry")
@@ -204,7 +250,7 @@ class _BlockBuilder:
     order: list[str] = field(default_factory=list)
     counter: int = 0
     current_id: str | None = None
-    declared_functions: dict[str, str] = field(default_factory=dict)
+    declared_functions: _Scope = field(default_factory=lambda: _Scope({}, {}))
     trace_scope: str = ""
 
     def new_block(self, hint: str) -> str:
@@ -330,7 +376,121 @@ def _lower_statement(statement: Any, builder: _BlockBuilder, *, loop: _LoopTarge
     if isinstance(statement, ForStatementNode):
         _lower_for(statement, builder)
         return
+    if isinstance(statement, MatchStatementNode):
+        _lower_match(statement, builder, loop=loop)
+        return
     raise LoweringError("IR-LOWER-005", f"unsupported statement: {type(statement).__name__}")
+
+
+def _lower_match(statement: MatchStatementNode, builder: _BlockBuilder, *, loop: _LoopTargets | None) -> None:
+    declared_functions = builder.declared_functions
+    if builder.current_terminator() is not None:
+        return
+    entry_block = builder.current_id
+    assert entry_block is not None
+    merge = builder.new_block("match_merge")
+    subject = _lower_expression(statement.expression, declared_functions)
+    arms: list[dict[str, Any]] = []
+    for arm in statement.arms:
+        arm_block = builder.new_block("match_arm")
+        builder.enter(arm_block)
+        _lower_statements(arm.body, builder, loop=loop)
+        if builder.current_terminator() is None:
+            builder.jump_to(merge)
+        arms.append({
+            "pattern": _lower_pattern(arm.pattern.pattern),
+            "guard": (
+                _lower_expression(arm.guard, declared_functions)
+                if arm.guard is not None
+                else None
+            ),
+            "target": arm_block,
+        })
+    # Every arm body above was lowered into its own fresh block while
+    # `builder`'s current block kept moving forward; only now, with every
+    # arm block built (and their bodies' own control flow -- including
+    # nested match/if -- already resolved), do we come back and terminate
+    # the block the match statement actually started in with the `match`
+    # dispatch itself (mirroring `_lower_if`'s deferred `branch`
+    # terminator, but for an N-way dispatch instead of 2-way).
+    builder.enter(entry_block)
+    builder.terminate({"kind": "match", "subject": subject, "arms": arms})
+    builder.enter(merge)
+
+
+def _lower_pattern(pattern: Any) -> dict[str, Any]:
+    if isinstance(pattern, (WildcardPatternNode, DefaultPatternNode)):
+        return {"kind": "wildcard"}
+    if isinstance(pattern, IdentifierPatternNode):
+        return {"kind": "binding", "name": pattern.name}
+    if isinstance(pattern, StructBindingPatternNode):
+        return {"kind": "binding", "name": pattern.binding}
+    if isinstance(pattern, LiteralPatternNode):
+        return {"kind": "literal", **_lower_pattern_literal(pattern.value)}
+    if isinstance(pattern, RangePatternNode):
+        return {
+            "kind": "range",
+            "lower": pattern.lower.value,
+            "upper": pattern.upper.value,
+            "lower_inclusive": pattern.lower_inclusive,
+            "upper_inclusive": pattern.upper_inclusive,
+        }
+    if isinstance(pattern, EnumValuePatternNode):
+        return {
+            "kind": "enum_value",
+            "enum_name": pattern.enum_name,
+            "variant_name": pattern.value_name,
+        }
+    if isinstance(pattern, QualifiedPatternNode):
+        return {
+            "kind": "enum_value",
+            "enum_name": pattern.namespace,
+            "variant_name": pattern.identifier,
+        }
+    if isinstance(pattern, OptionalPatternNode):
+        if pattern.kind == "Some":
+            inner = (
+                {"kind": "binding", "name": pattern.binding}
+                if pattern.binding is not None
+                else {"kind": "wildcard"}
+            )
+            return {"kind": "optional_some", "pattern": inner}
+        return {"kind": "optional_none"}
+    if isinstance(pattern, OptionalValuePatternNode):
+        if pattern.kind == "Some":
+            return {"kind": "optional_some", "pattern": _lower_pattern(pattern.pattern)}
+        return {"kind": "optional_none"}
+    if isinstance(pattern, StructPatternNode):
+        return {
+            "kind": "struct",
+            "type_name": pattern.type_name,
+            "fields": {
+                field.field_name: _lower_pattern(field.pattern)
+                for field in pattern.fields
+            },
+        }
+    if isinstance(pattern, OrPatternNode):
+        return {
+            "kind": "or",
+            "alternatives": [_lower_pattern(alternative) for alternative in pattern.alternatives],
+        }
+    raise LoweringError("IR-LOWER-012", f"unsupported pattern: {type(pattern).__name__}")
+
+
+def _lower_pattern_literal(value: Any) -> dict[str, Any]:
+    if isinstance(value, IntegerLiteralNode):
+        return {"value_kind": "int", "value": value.value}
+    if isinstance(value, FloatLiteralNode):
+        return {"value_kind": "float", "value": value.value}
+    if isinstance(value, BooleanLiteralNode):
+        return {"value_kind": "bool", "value": value.value}
+    if isinstance(value, StringLiteralNode):
+        return {"value_kind": "string", "value": value.value}
+    if isinstance(value, NullLiteralNode):
+        return {"value_kind": "null", "value": None}
+    raise LoweringError(
+        "IR-LOWER-012", f"unsupported literal pattern value: {type(value).__name__}"
+    )
 
 
 def _lower_if(statement: IfStatementNode, builder: _BlockBuilder, *, loop: _LoopTargets | None) -> None:
@@ -501,7 +661,7 @@ def _unwrap(value: Any) -> Any:
     return value.expression if isinstance(value, ExpressionNode) else value
 
 
-def _lower_expression(value: Any, declared_functions: dict[str, str]) -> dict[str, Any]:
+def _lower_expression(value: Any, declared_functions: _Scope) -> dict[str, Any]:
     value = _unwrap(value)
     source_span = getattr(value, "_source_location", None)
 
@@ -518,8 +678,21 @@ def _lower_expression(value: Any, declared_functions: dict[str, str]) -> dict[st
         return spanned({"op": "const", "kind": "bool", "value": value.value})
     if isinstance(value, StringLiteralNode):
         return spanned({"op": "const", "kind": "string", "value": value.value})
-    if isinstance(value, (NoneLiteralNode, NullLiteralNode)):
+    if isinstance(value, NullLiteralNode):
         return spanned({"op": "const", "kind": "null", "value": None})
+    if isinstance(value, NoneLiteralNode):
+        return spanned({"op": "optional_none"})
+    if isinstance(value, SomeExpressionNode):
+        return spanned({
+            "op": "optional_some",
+            "value": _lower_expression(value.value, declared_functions),
+        })
+    if isinstance(value, EnumVariantReferenceNode):
+        return spanned({
+            "op": "enum_value",
+            "enum_name": value.enum_name,
+            "variant_name": value.variant_name,
+        })
     if isinstance(value, IdentifierNode):
         return spanned({"op": "local", "name": value.name})
     if isinstance(value, ArrayLiteralNode):
@@ -566,6 +739,20 @@ def _lower_expression(value: Any, declared_functions: dict[str, str]) -> dict[st
             "index": _lower_expression(value.index, declared_functions),
         })
     if isinstance(value, MemberAccessNode):
+        if (
+            isinstance(value.object, IdentifierNode)
+            and value.object.name in declared_functions.enums
+        ):
+            enum_name = value.object.name
+            if value.member not in declared_functions.enums[enum_name]:
+                raise LoweringError(
+                    "IR-LOWER-013", f"unknown enum variant: {enum_name}.{value.member}"
+                )
+            return spanned({
+                "op": "enum_value",
+                "enum_name": enum_name,
+                "variant_name": value.member,
+            })
         return spanned({
             "op": "member",
             "object": _lower_expression(value.object, declared_functions),
@@ -595,7 +782,7 @@ def _lower_expression(value: Any, declared_functions: dict[str, str]) -> dict[st
     raise LoweringError("IR-LOWER-006", f"unsupported expression: {type(value).__name__}")
 
 
-def _lower_call(value: CallExpressionNode, declared_functions: dict[str, str]) -> dict[str, Any]:
+def _lower_call(value: CallExpressionNode, declared_functions: _Scope) -> dict[str, Any]:
     if (
         isinstance(value.callee, MemberAccessNode)
         and isinstance(value.callee.object, IdentifierNode)
@@ -650,7 +837,7 @@ def _lower_call(value: CallExpressionNode, declared_functions: dict[str, str]) -
     if (
         isinstance(value.callee, IdentifierNode)
         and value.callee.name in _SCALAR_CAST_NAMES
-        and value.callee.name not in declared_functions
+        and value.callee.name not in declared_functions.functions
     ):
         if len(value.arguments) != 1:
             raise LoweringError("IR-LOWER-008", f"{value.callee.name}() expects exactly one argument")
@@ -662,7 +849,7 @@ def _lower_call(value: CallExpressionNode, declared_functions: dict[str, str]) -
     if isinstance(value.callee, IdentifierNode):
         return {
             "op": "call_function",
-            "name": declared_functions.get(value.callee.name, value.callee.name),
+            "name": declared_functions.functions.get(value.callee.name, value.callee.name),
             "arguments": [_lower_expression(argument, declared_functions) for argument in value.arguments],
         }
     if isinstance(value.callee, QualifiedIdentifierNode):

--- a/frontend/computation_ir/optimizer.py
+++ b/frontend/computation_ir/optimizer.py
@@ -235,11 +235,21 @@ def _terminator_is_pure(
     pure,
     active: frozenset[str],
 ) -> bool:
-    return all(
+    if not all(
         _expr_is_pure_function_body(terminator[key], functions, pure, active)
         for key in ("condition", "value")
         if key in terminator
-    )
+    ):
+        return False
+    if terminator.get("kind") == "match":
+        if not _expr_is_pure_function_body(terminator["subject"], functions, pure, active):
+            return False
+        return all(
+            arm["guard"] is None
+            or _expr_is_pure_function_body(arm["guard"], functions, pure, active)
+            for arm in terminator["arms"]
+        )
+    return True
 
 
 def _expr_is_pure_function_body(
@@ -431,6 +441,12 @@ def _fold_terminator(terminator: dict[str, Any]) -> dict[str, Any]:
         terminator["condition"] = _fold_expr(terminator["condition"])
     if "value" in terminator:
         terminator["value"] = _fold_expr(terminator["value"])
+    if terminator.get("kind") == "match":
+        terminator["subject"] = _fold_expr(terminator["subject"])
+        terminator["arms"] = [
+            {**arm, "guard": _fold_expr(arm["guard"]) if arm["guard"] is not None else None}
+            for arm in terminator["arms"]
+        ]
     return terminator
 
 
@@ -526,6 +542,8 @@ def _fold_expr(expr: dict[str, Any]) -> dict[str, Any]:
             value = float(argument["value"]) if expr["name"] == "float" else int(argument["value"])
             return _const("float" if expr["name"] == "float" else "int", value)
         return {**expr, "argument": argument}
+    if op == "optional_some":
+        return {**expr, "value": _fold_expr(expr["value"])}
     return expr
 
 
@@ -559,6 +577,8 @@ def _reachable_block_ids(blocks_by_id: dict[str, dict[str, Any]], entry: str) ->
         elif terminator["kind"] == "branch":
             stack.append(terminator["then"])
             stack.append(terminator["else"])
+        elif terminator["kind"] == "match":
+            stack.extend(arm["target"] for arm in terminator["arms"])
     return seen
 
 
@@ -646,18 +666,21 @@ def _hoist_loop_invariants(
     return result
 
 
+def _terminator_targets(terminator: dict[str, Any]) -> list[str]:
+    kind = terminator.get("kind")
+    if kind == "jump":
+        return [terminator["target"]]
+    if kind == "branch":
+        return [terminator["then"], terminator["else"]]
+    if kind == "match":
+        return [arm["target"] for arm in terminator["arms"]]
+    return []
+
+
 def _predecessors(blocks_by_id: dict[str, dict[str, Any]]) -> dict[str, set[str]]:
     result: dict[str, set[str]] = {block_id: set() for block_id in blocks_by_id}
     for block_id, block in blocks_by_id.items():
-        terminator = block["terminator"]
-        targets = (
-            [terminator["target"]]
-            if terminator.get("kind") == "jump"
-            else [terminator["then"], terminator["else"]]
-            if terminator.get("kind") == "branch"
-            else []
-        )
-        for target in targets:
+        for target in _terminator_targets(block["terminator"]):
             result.setdefault(target, set()).add(block_id)
     return result
 
@@ -673,10 +696,7 @@ def _loop_region(
             continue
         region.add(block_id)
         terminator = blocks_by_id[block_id]["terminator"]
-        if terminator.get("kind") == "jump":
-            stack.append(terminator["target"])
-        elif terminator.get("kind") == "branch":
-            stack.extend((terminator["then"], terminator["else"]))
+        stack.extend(_terminator_targets(terminator))
     return region
 
 
@@ -742,6 +762,11 @@ def _eliminate_dead_locals(
             _collect_reads(terminator["condition"], read_names)
         if "value" in terminator:
             _collect_reads(terminator["value"], read_names)
+        if terminator.get("kind") == "match":
+            _collect_reads(terminator["subject"], read_names)
+            for arm in terminator["arms"]:
+                if arm["guard"] is not None:
+                    _collect_reads(arm["guard"], read_names)
 
     result = {}
     for block_id, block in blocks_by_id.items():
@@ -798,6 +823,9 @@ def _collect_reads(expr: dict[str, Any], out: set[str]) -> None:
     if op == "call_cast":
         _collect_reads(expr["argument"], out)
         return
+    if op == "optional_some":
+        _collect_reads(expr["value"], out)
+        return
 
 
 _IMPURE_FUNCTION_IDS = {"tensor.load", "tensor.save"}
@@ -829,6 +857,8 @@ def _is_side_effect_free(expr: dict[str, Any]) -> bool:
         return _is_side_effect_free(expr["collection"]) and _is_side_effect_free(expr["item"])
     if op == "call_cast":
         return _is_side_effect_free(expr["argument"])
+    if op == "optional_some":
+        return _is_side_effect_free(expr["value"])
     if op == "array":
         return all(_is_side_effect_free(item) for item in expr["elements"])
     if op == "struct":
@@ -921,4 +951,8 @@ def _is_cse_eligible(expr: dict[str, Any]) -> bool:
         return _is_cse_eligible(expr["object"])
     if op == "call_cast":
         return _is_cse_eligible(expr["argument"])
+    if op in ("enum_value", "optional_none"):
+        return True
+    if op == "optional_some":
+        return _is_cse_eligible(expr["value"])
     return False

--- a/frontend/computation_ir/schema.py
+++ b/frontend/computation_ir/schema.py
@@ -1,36 +1,41 @@
-"""reason-computation-ir/0.1 — schema constants.
+"""reason-computation-ir/0.2 — schema constants.
 
 This is the "Reason Computation IR" from the ReasonScript modernization
 plan (section 6), kept separate from the pre-existing `reason-ir/0.1`
 (state/goal/transition/constraint IR — see `toolchain.artifacts`). This
 IR is specifically for lowering executable calculation/function bodies
 (control flow + Tensor calls) to a basic-block form, as a step toward a
-future Rust computation runtime. Phase 2 scope is Python-only: this
-module defines the shape of the IR and is consumed by a temporary Python
-interpreter (`frontend.computation_ir.interpreter`), not by any Rust
-code yet.
+future Rust computation runtime.
 
 Everything here is plain JSON-serializable `dict`/`list`/scalar data
 (matching the plan's "Python frontend generates canonical JSON" transfer
 rule in section 6), not a dataclass hierarchy — this is what will
 eventually cross the Python/Rust boundary as JSON, so no Python-specific
 object identity or types should be relied upon by any downstream reader.
+
+0.2 adds `enum`, `optional` (`some(...)`/`none`), and `match` as tagged
+values with real pattern matching (Phase 1 of the enum/optional/match
+unification plan): the `enum_value`/`optional_some`/`optional_none`
+expression ops, and the `match` terminator kind together with the
+`PATTERN_KINDS` vocabulary consumed by its `arms`. `null` (`NullLiteralNode`)
+keeps lowering to plain `const:null` as before, distinct from `none`
+(`NoneLiteralNode`, now `optional_none`) — the two are no longer collapsed
+into the same IR shape.
 """
 
 from __future__ import annotations
 
-SCHEMA = "reason-computation-ir/0.1"
+SCHEMA = "reason-computation-ir/0.2"
 
-TERMINATOR_KINDS = ("jump", "branch", "return", "result", "trap")
+TERMINATOR_KINDS = ("jump", "branch", "return", "result", "trap", "match")
 
 # Expression IR node "op" tags. Deliberately not exhaustive over the full
 # ReasonScript language surface: scope is bounded to what
 # `frontend.integrated_computation_runtime` (the AST evaluator this IR is
 # differentially tested against) itself supports. Constructs outside this
-# set (pattern matching, Optional/Some, map/set literals, reason_object graph
-# queries)
-# are out of scope for this phase and are rejected by the lowering with a
-# clear "not supported" error rather than silently mishandled.
+# set (map/set literals, reason_object graph queries) are out of scope for
+# this phase and are rejected by the lowering with a clear "not supported"
+# error rather than silently mishandled.
 EXPRESSION_OPS = (
     "const",
     "local",
@@ -51,9 +56,38 @@ EXPRESSION_OPS = (
     "call_array_append",
     "call_function",
     "call_cast",
+    "enum_value",
+    "optional_some",
+    "optional_none",
 )
 
 INSTRUCTION_OPS = (
     "assign", "index_assign", "field_assign", "expr",
     "trace_loop_start", "trace_loop_end",
+)
+
+# Pattern "kind" tags used inside a `match` terminator's `arms`. Shared
+# vocabulary between `lowering.py` (AST Pattern -> JSON), `interpreter.py`
+# (JSON -> Python match), and the Rust decoder/VM (`ir.rs`/`vm.rs`'s
+# `Pattern` enum) -- all three must agree on this shape.
+#
+# `wildcard` covers both `_` (WildcardPatternNode) and `default`
+# (DefaultPatternNode): both match unconditionally with no binding.
+# `binding` covers both a bare identifier pattern and a struct
+# shorthand/rename binding (StructBindingPatternNode): matches
+# unconditionally and binds `name`.
+# `optional_some` always carries a nested `pattern` (a `binding` or
+# `wildcard` for the simple `Some(x)`/`Some(_)` forms, anything else for
+# `Some(<nested pattern>)`), unifying OptionalPatternNode and
+# OptionalValuePatternNode into one IR shape.
+PATTERN_KINDS = (
+    "wildcard",
+    "binding",
+    "literal",
+    "range",
+    "enum_value",
+    "optional_some",
+    "optional_none",
+    "struct",
+    "or",
 )

--- a/frontend/computation_ir/validation.py
+++ b/frontend/computation_ir/validation.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .schema import EXPRESSION_OPS, INSTRUCTION_OPS, SCHEMA, TERMINATOR_KINDS
+from .schema import EXPRESSION_OPS, INSTRUCTION_OPS, PATTERN_KINDS, SCHEMA, TERMINATOR_KINDS
 
 
 def validate_program(document: dict[str, Any]) -> list[str]:
@@ -90,6 +90,21 @@ def _validate_terminator(function_id: str, block_id: str, terminator: Any, block
         errors.extend(_validate_expression(where, terminator.get("condition")))
     if kind in ("result", "return"):
         errors.extend(_validate_expression(where, terminator.get("value")))
+    if kind == "match":
+        errors.extend(_validate_expression(where, terminator.get("subject")))
+        arms = terminator.get("arms")
+        if not isinstance(arms, list) or not arms:
+            errors.append(f"{where}: match 'arms' must be a non-empty list")
+        else:
+            for index, arm in enumerate(arms):
+                if not isinstance(arm, dict):
+                    errors.append(f"{where}: match arm {index} is not an object")
+                    continue
+                errors.extend(_validate_pattern(where, arm.get("pattern")))
+                if arm.get("guard") is not None:
+                    errors.extend(_validate_expression(where, arm["guard"]))
+                if arm.get("target") not in block_ids:
+                    errors.append(f"{where}: match arm {index} target {arm.get('target')!r} unknown")
     return errors
 
 
@@ -100,6 +115,8 @@ def _validate_expression(where: str, node: Any) -> list[str]:
     for key in ("left", "right", "operand", "collection", "index", "object", "argument"):
         if key in node:
             errors.extend(_validate_expression(where, node[key]))
+    if node["op"] == "optional_some" and "value" in node:
+        errors.extend(_validate_expression(where, node["value"]))
     for key in ("elements", "arguments"):
         if key in node:
             for item in node[key]:
@@ -107,6 +124,30 @@ def _validate_expression(where: str, node: Any) -> list[str]:
     if "fields" in node:
         for value in node["fields"].values():
             errors.extend(_validate_expression(where, value))
+    return errors
+
+
+def _validate_pattern(where: str, pattern: Any) -> list[str]:
+    if not isinstance(pattern, dict) or pattern.get("kind") not in PATTERN_KINDS:
+        return [f"{where}: invalid pattern node: {pattern!r}"]
+    kind = pattern["kind"]
+    errors: list[str] = []
+    if kind == "optional_some":
+        errors.extend(_validate_pattern(where, pattern.get("pattern")))
+    if kind == "struct":
+        fields = pattern.get("fields")
+        if not isinstance(fields, dict):
+            errors.append(f"{where}: struct pattern 'fields' must be an object")
+        else:
+            for field_pattern in fields.values():
+                errors.extend(_validate_pattern(where, field_pattern))
+    if kind == "or":
+        alternatives = pattern.get("alternatives")
+        if not isinstance(alternatives, list) or not alternatives:
+            errors.append(f"{where}: or-pattern 'alternatives' must be a non-empty list")
+        else:
+            for alternative in alternatives:
+                errors.extend(_validate_pattern(where, alternative))
     return errors
 
 
@@ -124,4 +165,8 @@ def _reachable_blocks(entry: str, blocks_by_id: dict[str, dict[str, Any]]) -> se
         elif terminator.get("kind") == "branch":
             stack.append(terminator.get("then"))
             stack.append(terminator.get("else"))
+        elif terminator.get("kind") == "match":
+            for arm in terminator.get("arms") or []:
+                if isinstance(arm, dict):
+                    stack.append(arm.get("target"))
     return seen

--- a/frontend/integrated_computation_runtime.py
+++ b/frontend/integrated_computation_runtime.py
@@ -20,6 +20,10 @@ from frontend.language_surface.nodes import (
     ComparisonOperator,
     ConstStatementNode,
     ContinueStatementNode,
+    DefaultPatternNode,
+    EnumDeclarationNode,
+    EnumValuePatternNode,
+    EnumVariantReferenceNode,
     ExpressionNode,
     ExpressionStatementNode,
     FieldAssignmentStatementNode,
@@ -28,34 +32,46 @@ from frontend.language_surface.nodes import (
     FunctionDeclarationNode,
     GoalNode,
     IdentifierNode,
+    IdentifierPatternNode,
     IfStatementNode,
     ImportNode,
     IndexAccessNode,
     IndexAssignmentStatementNode,
     IntegerLiteralNode,
     LetStatementNode,
+    LiteralPatternNode,
     LogicalExpressionNode,
     LogicalOperator,
     LoopStatementNode,
+    MatchStatementNode,
     MemberAccessNode,
     NoneLiteralNode,
     NullLiteralNode,
+    OptionalPatternNode,
+    OptionalValuePatternNode,
+    OrPatternNode,
     ParenthesizedExpressionNode,
     ProgramNode,
     QualifiedIdentifierNode,
+    QualifiedPatternNode,
+    RangePatternNode,
     ReasonGraphDeclarationNode,
     ReasonObjectBindingNode,
     ResultStatementNode,
     ReturnStatementNode,
     RuntimeCallExpressionNode,
+    SomeExpressionNode,
     StateDeclarationNode,
     ConstraintNode,
     ExecutionPlanDeclarationNode,
     StringLiteralNode,
+    StructBindingPatternNode,
     StructLiteralNode,
+    StructPatternNode,
     UnaryExpressionNode,
     UnaryOperator,
     WhileStatementNode,
+    WildcardPatternNode,
 )
 from frontend.relation.integration import relation_call_name
 from frontend.reason_object_runtime import (
@@ -105,6 +121,34 @@ class RuntimeStruct:
     fields: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class RuntimeEnumValue:
+    """A resolved `EnumName.VariantName` reference (Phase 1 enum unification).
+
+    Distinct from a plain string so `Color.Red == "Red"` is a type error
+    the way `TYPE-V004`-style arithmetic mixing is, not an accidental true
+    -- equality/pattern matching only ever compares two `RuntimeEnumValue`s.
+    """
+
+    enum_name: str
+    variant_name: str
+
+
+@dataclass(frozen=True)
+class RuntimeOptionalValue:
+    """`some(x)` / `none` (Phase 1 optional unification).
+
+    Deliberately not the same value as ReasonScript `null`
+    (`NullLiteralNode`, which still evaluates to plain Python `None`): a
+    `none` is a tagged "absent" `RuntimeOptionalValue`, so
+    `none == null` is false and a `None`/`Some` match arm can't
+    accidentally catch an unrelated `null`.
+    """
+
+    has_value: bool
+    value: Any = None
+
+
 @dataclass
 class RuntimeFunction:
     node: FunctionDeclarationNode
@@ -144,6 +188,83 @@ def _relation_field(row: RuntimeStruct, field: str) -> Any:
     if field not in row.fields:
         raise IntegratedRuntimeError("REL-005", f"unknown field {field} on {row.type_name}")
     return row.fields[field]
+
+
+def _match_pattern(pattern: Any, value: Any) -> dict[str, Any] | None:
+    """Structurally matches `value` against a `Pattern` AST node.
+
+    Returns the bindings a successful match would introduce (possibly
+    empty), or `None` if `pattern` does not match `value`. Language-surface
+    validation (`_validate_*_match_exhaustiveness` in
+    `frontend.language_surface.validation`) already guarantees a `match`
+    statement is exhaustive before this ever runs, so callers only need to
+    handle "no arm matched" as a defensive fallback, not an expected case.
+    """
+    if isinstance(pattern, (WildcardPatternNode, DefaultPatternNode)):
+        return {}
+    if isinstance(pattern, IdentifierPatternNode):
+        return {pattern.name: value}
+    if isinstance(pattern, StructBindingPatternNode):
+        return {pattern.binding: value}
+    if isinstance(pattern, LiteralPatternNode):
+        literal = pattern.value
+        literal_value = None if isinstance(literal, NullLiteralNode) else literal.value
+        return {} if value == literal_value else None
+    if isinstance(pattern, RangePatternNode):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        lower = pattern.lower.value
+        upper = pattern.upper.value
+        lower_ok = value >= lower if pattern.lower_inclusive else value > lower
+        upper_ok = value <= upper if pattern.upper_inclusive else value < upper
+        return {} if lower_ok and upper_ok else None
+    if isinstance(pattern, EnumValuePatternNode):
+        matches = (
+            isinstance(value, RuntimeEnumValue)
+            and value.enum_name == pattern.enum_name
+            and value.variant_name == pattern.value_name
+        )
+        return {} if matches else None
+    if isinstance(pattern, QualifiedPatternNode):
+        matches = (
+            isinstance(value, RuntimeEnumValue)
+            and value.enum_name == pattern.namespace
+            and value.variant_name == pattern.identifier
+        )
+        return {} if matches else None
+    if isinstance(pattern, OptionalPatternNode):
+        if not isinstance(value, RuntimeOptionalValue):
+            return None
+        if pattern.kind == "Some":
+            if not value.has_value:
+                return None
+            return {pattern.binding: value.value} if pattern.binding is not None else {}
+        return {} if not value.has_value else None
+    if isinstance(pattern, OptionalValuePatternNode):
+        if not isinstance(value, RuntimeOptionalValue):
+            return None
+        if pattern.kind == "Some":
+            return _match_pattern(pattern.pattern, value.value) if value.has_value else None
+        return {} if not value.has_value else None
+    if isinstance(pattern, StructPatternNode):
+        if not isinstance(value, RuntimeStruct) or value.type_name != pattern.type_name:
+            return None
+        bindings: dict[str, Any] = {}
+        for field in pattern.fields:
+            if field.field_name not in value.fields:
+                return None
+            sub_bindings = _match_pattern(field.pattern, value.fields[field.field_name])
+            if sub_bindings is None:
+                return None
+            bindings.update(sub_bindings)
+        return bindings
+    if isinstance(pattern, OrPatternNode):
+        for alternative in pattern.alternatives:
+            bindings = _match_pattern(alternative, value)
+            if bindings is not None:
+                return bindings
+        return None
+    raise IntegratedRuntimeError("RT-MATCH-002", f"unsupported pattern: {type(pattern).__name__}")
 
 
 def call_relation(function_id: str, *args: Any) -> Any:
@@ -253,8 +374,22 @@ def execute_program(
     calculations: dict[str, Any] = {}
     object_root = (resource_root or Path.cwd()).resolve()
     module_objects: dict[str, dict[str, Any]] = {}
+    # Flat and program-wide, like `RuntimeStruct.type_name`: every module
+    # sees every declared enum's namespace object below, so `Color.Red`
+    # resolves via the ordinary `MemberAccessNode` handling in
+    # `_expression` (env lookup of "Color" finds this dict, then plain
+    # dict-member lookup) without needing a dedicated AST node or a
+    # separate scope parameter threaded through every evaluator call.
+    enum_namespaces: dict[str, dict[str, RuntimeEnumValue]] = {
+        item.name: {
+            value.name: RuntimeEnumValue(item.name, value.name) for value in item.values
+        }
+        for module in program.modules
+        for item in module.body
+        if isinstance(item, EnumDeclarationNode)
+    }
     for module in program.modules:
-        loaded: dict[str, Any] = {}
+        loaded: dict[str, Any] = dict(enum_namespaces)
         for item in module.body:
             if isinstance(item, (
                 GoalNode,
@@ -449,7 +584,54 @@ def _statements(
                     selected, env, runtime, trace, limit, scope, vision_runtime,
                     functions, max_call_depth, call_depth,
                 )
+        elif isinstance(statement, MatchStatementNode):
+            _match_statement(
+                statement, env, runtime, trace, limit, scope, vision_runtime,
+                functions, max_call_depth, call_depth,
+            )
         runtime.collect(env)
+
+
+def _match_statement(
+    statement: MatchStatementNode,
+    env: dict[str, Any],
+    runtime: TensorRuntime,
+    trace: list[dict[str, Any]],
+    limit: int,
+    scope: str,
+    vision_runtime: VisionRuntimeBridge,
+    functions: dict[str, FunctionDeclarationNode],
+    max_call_depth: int,
+    call_depth: int,
+) -> None:
+    subject = _expression(
+        statement.expression, env, runtime, vision_runtime,
+        functions, max_call_depth, call_depth,
+    )
+    for arm in statement.arms:
+        bindings = _match_pattern(arm.pattern.pattern, subject)
+        if bindings is None:
+            continue
+        previous: list[tuple[str, Any, bool]] = [
+            (name, env.get(name), name in env) for name in bindings
+        ]
+        env.update(bindings)
+        guard_ok = arm.guard is None or bool(_expression(
+            arm.guard, env, runtime, vision_runtime,
+            functions, max_call_depth, call_depth,
+        ))
+        if guard_ok:
+            _statements(
+                arm.body, env, runtime, trace, limit, scope, vision_runtime,
+                functions, max_call_depth, call_depth,
+            )
+            return
+        for name, old_value, existed in previous:
+            if existed:
+                env[name] = old_value
+            else:
+                del env[name]
+    raise IntegratedRuntimeError("RT-MATCH-001", "no match arm satisfied the value")
 
 
 def _while_loop(
@@ -540,8 +722,17 @@ def _expression(
     value = value.expression if isinstance(value, ExpressionNode) else value
     if isinstance(value, (IntegerLiteralNode, FloatLiteralNode, BooleanLiteralNode, StringLiteralNode)):
         return value.value
-    if isinstance(value, (NoneLiteralNode, NullLiteralNode)):
+    if isinstance(value, NullLiteralNode):
         return None
+    if isinstance(value, NoneLiteralNode):
+        return RuntimeOptionalValue(False)
+    if isinstance(value, SomeExpressionNode):
+        return RuntimeOptionalValue(True, _expression(
+            value.value, env, runtime, vision_runtime,
+            functions, max_call_depth, call_depth,
+        ))
+    if isinstance(value, EnumVariantReferenceNode):
+        return RuntimeEnumValue(value.enum_name, value.variant_name)
     if isinstance(value, IdentifierNode):
         if value.name not in env:
             raise IntegratedRuntimeError("RT-NAME-001", f"unknown runtime name: {value.name}")
@@ -964,6 +1155,14 @@ def _plain(value: Any, runtime: TensorRuntime) -> Any:
             name: _plain(item, runtime)
             for name, item in sorted(value.fields.items())
         }
+    if isinstance(value, RuntimeEnumValue):
+        return {"enum_name": value.enum_name, "variant_name": value.variant_name}
+    if isinstance(value, RuntimeOptionalValue):
+        return (
+            {"optional": "some", "value": _plain(value.value, runtime)}
+            if value.has_value
+            else {"optional": "none"}
+        )
     if hasattr(value, "to_runtime_value"):
         return _plain(value.to_runtime_value(), runtime)
     if isinstance(value, dict):
@@ -984,6 +1183,14 @@ def _trace_plain(value: Any) -> Any:
             name: _trace_plain(item)
             for name, item in sorted(value.fields.items())
         }
+    if isinstance(value, RuntimeEnumValue):
+        return {"enum_name": value.enum_name, "variant_name": value.variant_name}
+    if isinstance(value, RuntimeOptionalValue):
+        return (
+            {"optional": "some", "value": _trace_plain(value.value)}
+            if value.has_value
+            else {"optional": "none"}
+        )
     if hasattr(value, "to_runtime_value"):
         return _trace_plain(value.to_runtime_value())
     if isinstance(value, dict):


### PR DESCRIPTION
## Summary
- Bumps the Computation IR schema to `reason-computation-ir/0.2` and adds real execution for `enum` values, `some(...)`/`none`, and `match`/pattern matching across every evaluator: the AST oracle (`integrated_computation_runtime.py`), the Python IR interpreter, and the Rust VM (`value.rs`/`ir.rs`/`vm.rs`).
- `none` is now a tagged `RuntimeOptionalValue` distinct from plain `null`; enum references resolve via a `Color.Red -> RuntimeEnumValue` path shared by both interpreters.
- Fixes a critical pre-existing gap in `optimizer.py`: its reachability/purity/liveness passes didn't know a `match` terminator has per-arm successors, so any program using `match` would have its arm blocks deleted as "unreachable" during `reason build`/`reason check`, crashing the interpreter with a `KeyError` on the now-dangling arm targets.

## Test plan
- [x] `pytest computation_ir_tests/` — 191 passed (new differential, Rust-parity, and optimizer-regression tests for enum/optional/match)
- [x] Full Python suite (`pytest -q`) — 2262 passed (1 pre-existing, unrelated environment failure: missing VS Code extension `node_modules`)
- [x] `cargo test --manifest-path ReasonRuntime/Cargo.toml --workspace` — all green, including 4 new inline VM tests for match/enum/optional
- [x] `cargo clippy -p reasonscript-computation-ir -p reasonscript-computation-runtime-cli` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)