### PR TITLE
Add string.* standard library and array.concat (Phase 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux desktop dependencies
         run: |
@@ -26,6 +29,9 @@ jobs:
             pkg-config
       - run: python3 -m pip install --upgrade pip
       - run: python3 -m pip install -r requirements-dev.txt
+      - name: Install VS Code extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
       - name: Fetch Rust dependencies
         run: |
           for manifest in */Cargo.toml; do

--- a/ReasonRuntime/crates/computation-ir/src/ir.rs
+++ b/ReasonRuntime/crates/computation-ir/src/ir.rs
@@ -283,6 +283,20 @@ pub enum Expr {
         #[serde(default)]
         source_span: Option<serde_json::Value>,
     },
+    #[serde(rename = "call_array_concat")]
+    CallArrayConcat {
+        left: Box<Expr>,
+        right: Box<Expr>,
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
+    #[serde(rename = "call_string")]
+    CallString {
+        function_id: String,
+        arguments: Vec<Expr>,
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
     #[serde(rename = "call_function")]
     CallFunction {
         name: String,
@@ -337,6 +351,8 @@ impl Expr {
             | Expr::CallRelation { source_span, .. }
             | Expr::CallReasoning { source_span, .. }
             | Expr::CallArrayAppend { source_span, .. }
+            | Expr::CallArrayConcat { source_span, .. }
+            | Expr::CallString { source_span, .. }
             | Expr::CallFunction { source_span, .. }
             | Expr::CallCast { source_span, .. }
             | Expr::EnumValue { source_span, .. }

--- a/ReasonRuntime/crates/computation-ir/src/lib.rs
+++ b/ReasonRuntime/crates/computation-ir/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ir;
 pub mod optimizer_dispatch;
 pub mod relation_dispatch;
 pub mod ruo_dispatch;
+pub mod string_dispatch;
 pub mod tensor_dispatch;
 pub mod value;
 pub mod vision_dispatch;

--- a/ReasonRuntime/crates/computation-ir/src/string_dispatch.rs
+++ b/ReasonRuntime/crates/computation-ir/src/string_dispatch.rs
@@ -1,0 +1,151 @@
+//! Dispatches `string.*` IR calls: the Phase 2 "String標準ライブラリ"
+//! minimal set (see `frontend/string/integration.py` for the full design
+//! rationale -- extending `+` to strings would make the existing
+//! numeric-only arithmetic type rule ambiguous, so this is a namespaced
+//! function set instead).
+//!
+//! Every function is a pure transformation over `Value::String`/`Int`/
+//! `Float`/`Array<String>` arguments -- no `TensorStore`, no persistent
+//! state, matching `relation_dispatch`.
+
+use std::rc::Rc;
+
+use crate::value::Value;
+use crate::vm::RuntimeError;
+
+type VResult = Result<Value, RuntimeError>;
+
+pub fn call(function_id: &str, mut args: Vec<Value>) -> VResult {
+    let name = function_id.strip_prefix("string.").unwrap_or(function_id);
+    let expected = match name {
+        "concat" | "join" => 2,
+        "length" | "from_int" | "from_float" => 1,
+        "slice" => 3,
+        _ => {
+            return Err(RuntimeError::new(
+                "STR-001",
+                format!("unknown String function: {function_id}"),
+            ))
+        }
+    };
+    if args.len() != expected {
+        return Err(RuntimeError::new(
+            "STR-002",
+            format!("String function argument count mismatch: {function_id} expects {expected}"),
+        ));
+    }
+    match name {
+        "concat" => {
+            let b = as_string(&args.remove(1), function_id)?;
+            let a = as_string(&args.remove(0), function_id)?;
+            Ok(Value::String(Rc::from(format!("{a}{b}").as_str())))
+        }
+        "join" => {
+            let values = as_string_array(&args.remove(1), function_id)?;
+            let separator = as_string(&args.remove(0), function_id)?;
+            Ok(Value::String(Rc::from(values.join(&separator).as_str())))
+        }
+        "length" => {
+            let value = as_string(&args.remove(0), function_id)?;
+            Ok(Value::Int(value.chars().count() as i64))
+        }
+        "from_int" => {
+            let value = as_int(&args.remove(0), function_id)?;
+            Ok(Value::String(Rc::from(value.to_string().as_str())))
+        }
+        "from_float" => {
+            let value = as_float(&args.remove(0), function_id)?;
+            Ok(Value::String(Rc::from(format_float(value).as_str())))
+        }
+        "slice" => {
+            let end = as_int(&args.remove(2), function_id)?;
+            let start = as_int(&args.remove(1), function_id)?;
+            let value = as_string(&args.remove(0), function_id)?;
+            let chars: Vec<char> = value.chars().collect();
+            let length = chars.len() as i64;
+            if start < 0 || end < start || end > length {
+                return Err(RuntimeError::new(
+                    "STR-004",
+                    format!("string.slice bounds out of range: {start}..{end}"),
+                ));
+            }
+            let sliced: String = chars[start as usize..end as usize].iter().collect();
+            Ok(Value::String(Rc::from(sliced.as_str())))
+        }
+        _ => unreachable!("caller already matched name against this exact set"),
+    }
+}
+
+/// Canonical `Float -> String` text, matched byte-for-byte by the Python
+/// interpreter's `integrated_computation_runtime.format_float` for the
+/// normal range (both sides use a shortest-round-trip digit algorithm
+/// that agrees digit-for-digit; only extreme magnitudes, where Python
+/// switches to scientific notation and Rust never does, are not
+/// guaranteed to match -- see that function's docstring).
+pub fn format_float(value: f64) -> String {
+    if value.is_nan() {
+        return "nan".to_string();
+    }
+    let text = format!("{value}");
+    if text.contains('.') || text.contains('e') || text.contains("inf") {
+        text
+    } else {
+        format!("{text}.0")
+    }
+}
+
+fn as_string(value: &Value, function_id: &str) -> Result<String, RuntimeError> {
+    match value {
+        Value::String(value) => Ok(value.to_string()),
+        other => Err(RuntimeError::new(
+            "STR-003",
+            format!(
+                "{function_id} argument must be String, got {}",
+                other.type_name()
+            ),
+        )),
+    }
+}
+
+fn as_string_array(value: &Value, function_id: &str) -> Result<Vec<String>, RuntimeError> {
+    match value {
+        Value::Array(items) => items
+            .borrow()
+            .iter()
+            .map(|item| as_string(item, function_id))
+            .collect(),
+        other => Err(RuntimeError::new(
+            "STR-003",
+            format!(
+                "{function_id} second argument must be Array<String>, got {}",
+                other.type_name()
+            ),
+        )),
+    }
+}
+
+fn as_int(value: &Value, function_id: &str) -> Result<i64, RuntimeError> {
+    match value {
+        Value::Int(value) => Ok(*value),
+        other => Err(RuntimeError::new(
+            "STR-003",
+            format!(
+                "{function_id} argument must be Int, got {}",
+                other.type_name()
+            ),
+        )),
+    }
+}
+
+fn as_float(value: &Value, function_id: &str) -> Result<f64, RuntimeError> {
+    match value {
+        Value::Float(value) => Ok(*value),
+        other => Err(RuntimeError::new(
+            "STR-003",
+            format!(
+                "{function_id} argument must be Float, got {}",
+                other.type_name()
+            ),
+        )),
+    }
+}

--- a/ReasonRuntime/crates/computation-ir/src/vm.rs
+++ b/ReasonRuntime/crates/computation-ir/src/vm.rs
@@ -928,6 +928,41 @@ impl<'a> Vm<'a> {
                     )),
                 }
             }
+            Expr::CallArrayConcat { left, right, .. } => {
+                let _guard = TempRootGuard::new(self);
+                let left_value = self.eval_expr(left, env, call_depth)?;
+                self.push_temporary_root(left_value.clone());
+                let right_value = self.eval_expr(right, env, call_depth)?;
+                match (left_value, right_value) {
+                    (Value::Array(left_items), Value::Array(right_items)) => {
+                        let mut new_items = left_items.borrow().clone();
+                        new_items.extend(right_items.borrow().iter().cloned());
+                        Ok(Value::Array(Rc::new(RefCell::new(new_items))))
+                    }
+                    (left, right) => Err(RuntimeError::new(
+                        "RT-CALL-006",
+                        format!(
+                            "array.concat arguments must be arrays, got {} and {}",
+                            left.type_name(),
+                            right.type_name()
+                        ),
+                    )),
+                }
+            }
+            Expr::CallString {
+                function_id,
+                arguments,
+                ..
+            } => {
+                let _guard = TempRootGuard::new(self);
+                let mut values = Vec::with_capacity(arguments.len());
+                for argument in arguments {
+                    let val = self.eval_expr(argument, env, call_depth)?;
+                    self.push_temporary_root(val.clone());
+                    values.push(val);
+                }
+                crate::string_dispatch::call(function_id, values)
+            }
             Expr::CallCast { name, argument, .. } => {
                 let value = self.eval_expr(argument, env, call_depth)?;
                 let numeric = match value {

--- a/computation_ir_tests/test_computation_ir_optimizer.py
+++ b/computation_ir_tests/test_computation_ir_optimizer.py
@@ -620,6 +620,91 @@ class RelationFunctionsInteractionTests(OptimizerParityMixin, unittest.TestCase)
         self.assertEqual(len(filter_calls), 2)
 
 
+class StringFunctionsInteractionTests(OptimizerParityMixin, unittest.TestCase):
+    """Phase 2: the `string.*` namespace and `array.concat`'s interaction
+    with the optimizer -- an unused call is dead-code-eliminated (and,
+    for `string.*`, a local read only inside its `arguments` must still
+    count as "used" -- `_collect_reads` needed an explicit `call_string`
+    branch or a local read only there would look dead), a used pipeline
+    survives optimization with an identical result, and repeated calls
+    are never CSE-merged (matching every other namespaced call)."""
+
+    def test_unused_string_call_is_eliminated(self):
+        ir = _lower(
+            """
+            module M {
+                calculation Answer {
+                    let unused = string.concat("a", "b")
+                    result = 1
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        for block in optimized["functions"][0]["blocks"]:
+            for instruction in block["instructions"]:
+                self.assertNotEqual(instruction.get("target"), "unused")
+
+    def test_local_read_only_inside_string_call_arguments_is_not_eliminated(self):
+        ir = _lower(
+            """
+            module M {
+                calculation Answer {
+                    let piece = "hello"
+                    result = string.length(piece)
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        assigns = [
+            instruction
+            for block in optimized["functions"][0]["blocks"]
+            for instruction in block["instructions"]
+            if instruction.get("op") == "assign" and instruction.get("target") == "piece"
+        ]
+        self.assertEqual(len(assigns), 1)
+
+    def test_string_and_array_concat_pipeline_survives_optimization(self):
+        optimized, results = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let unused = string.from_int(999)
+                    let combined = string.concat("foo", "bar")
+                    let letters = array.concat(["f", "o", "o"], ["b", "a", "r"])
+                    result = string.length(combined) * 100 + letters.length
+                }
+            }
+            """
+        )
+        self.assertEqual(results["Answer"], 606)
+        del optimized
+
+    def test_string_calls_are_never_deduplicated(self):
+        ir = _lower(
+            """
+            module M {
+                calculation Answer {
+                    let a = string.concat("x", "y")
+                    let b = string.concat("x", "y")
+                    result = string.length(a) + string.length(b)
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        concat_calls = [
+            instruction
+            for block in optimized["functions"][0]["blocks"]
+            for instruction in block["instructions"]
+            if instruction.get("op") == "assign"
+            and instruction["expr"].get("op") == "call_string"
+            and instruction["expr"].get("function_id") == "string.concat"
+        ]
+        self.assertEqual(len(concat_calls), 2)
+
+
 class MatchOptimizationTests(OptimizerParityMixin, unittest.TestCase):
     """Phase 1: the `match` terminator and `enum_value`/`optional_some`/
     `optional_none` expressions must survive every optimizer pass intact.

--- a/computation_ir_tests/test_computation_ir_string_functions.py
+++ b/computation_ir_tests/test_computation_ir_string_functions.py
@@ -1,0 +1,326 @@
+"""The `string.*` namespace and `array.concat`: Phase 2's "String／Collection標準ライブラリ".
+
+Minimal set: `string.concat`, `string.join`, `string.length`,
+`string.from_int`, `string.from_float`, `string.slice`, plus
+`array.concat` alongside the already-implemented `array.append`. `+` stays
+numeric-only (see `frontend/string/integration.py`'s module docstring for
+why a namespaced function set was chosen instead of extending `+`).
+
+Same differential pattern as every other `computation_ir_tests` parity
+suite: lower once, run through both `interpret_program` and the Rust CLI,
+assert `calculation_results` / error codes agree exactly. Rust comparisons
+are skipped (not failed) if the binary isn't built.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from frontend.computation_ir import interpret_program, lower_program, validate_program
+from frontend.computation_ir.rust_bridge import find_binary, run_ir
+from frontend.integrated_computation_runtime import IntegratedRuntimeError, LoopLimitError
+from frontend.language_surface import parse
+from frontend.language_surface.parser import SurfaceSyntaxError
+
+_BINARY = find_binary()
+
+
+def _lower(source: str):
+    return lower_program(parse(source))
+
+
+def _python_outcome(source: str):
+    ir = _lower(source)
+    try:
+        result = interpret_program(ir)
+    except (IntegratedRuntimeError, LoopLimitError) as error:
+        return None, getattr(error, "code", None)
+    return dict(result.calculation_results), None
+
+
+def _rust_outcome(source: str):
+    ir = _lower(source)
+    outcome = run_ir(ir, binary=_BINARY)
+    if outcome.ok:
+        return outcome.calculation_results, None
+    return None, outcome.error_code
+
+
+class StringParityMixin:
+    def assert_parity(self, source: str):
+        ir = _lower(source)
+        self.assertEqual(validate_program(ir), [])
+        python_results, python_error = _python_outcome(source)
+        if _BINARY is not None:
+            rust_results, rust_error = _rust_outcome(source)
+            self.assertEqual(python_error, rust_error, f"error code mismatch for:\n{source}")
+            if python_error is None:
+                self.assertEqual(python_results, rust_results, f"result mismatch for:\n{source}")
+        return python_results, python_error
+
+
+class StringFunctionTests(StringParityMixin, unittest.TestCase):
+    def test_concat_joins_two_strings(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.concat("foo", "bar")
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "foobar")
+
+    def test_join_uses_separator_between_every_element(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let values = ["a", "b", "c"]
+                    result = string.join("-", values)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "a-b-c")
+
+    def test_join_of_empty_array_is_empty_string(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let values: [string] = []
+                    result = string.join(",", values)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "")
+
+    def test_length_counts_characters(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.length("hello")
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 5)
+
+    def test_from_int_formats_negative_numbers(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.from_int(-7)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "-7")
+
+    def test_from_float_keeps_a_decimal_point_for_whole_numbers(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.from_float(2.0)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "2.0")
+
+    def test_from_float_keeps_fractional_digits(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.from_float(3.14)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "3.14")
+
+    def test_slice_extracts_a_substring(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.slice("hello world", 6, 11)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "world")
+
+    def test_slice_of_full_range_returns_original_string(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let value = "hello"
+                    result = string.slice(value, 0, string.length(value))
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], "hello")
+
+    def test_slice_out_of_range_reports_str_004_on_both_backends(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.slice("hi", 0, 5)
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "STR-004")
+
+    def test_slice_end_before_start_reports_str_004_on_both_backends(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    result = string.slice("hello", 3, 1)
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "STR-004")
+
+    def test_composed_pipeline_concat_then_slice_then_length(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let whole = string.concat("hello", " world")
+                    let front = string.slice(whole, 0, 5)
+                    result = string.length(front)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 5)
+
+
+class ArrayConcatTests(StringParityMixin, unittest.TestCase):
+    def test_concat_combines_two_arrays_in_order(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let combined = array.concat([1, 2], [3, 4])
+                    result = combined
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], [1, 2, 3, 4])
+
+    def test_concat_does_not_mutate_either_source_array(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let a = [1, 2]
+                    let b = [3, 4]
+                    let combined = array.concat(a, b)
+                    result = a.length * 100 + b.length
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 202)
+
+    def test_concat_with_empty_array_returns_equivalent_array(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let empty: [int] = []
+                    let combined = array.concat(empty, [1, 2, 3])
+                    result = combined
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], [1, 2, 3])
+
+
+class SurfaceValidationTests(unittest.TestCase):
+    """`string.*`/`array.concat` type errors are caught before lowering,
+    matching how `array.append` and `relation.*` are validated."""
+
+    def test_string_concat_rejects_non_string_argument(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        result = string.concat("foo", 1)
+                    }
+                }
+                """
+            )
+
+    def test_string_from_int_rejects_string_argument(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        result = string.from_int("1")
+                    }
+                }
+                """
+            )
+
+    def test_string_concat_argument_count_mismatch_is_rejected(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        result = string.concat("only-one")
+                    }
+                }
+                """
+            )
+
+    def test_array_concat_rejects_mismatched_element_types(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        let a = [1, 2]
+                        let b = ["x", "y"]
+                        result = array.concat(a, b)
+                    }
+                }
+                """
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/computation_ir/interpreter.py
+++ b/frontend/computation_ir/interpreter.py
@@ -31,6 +31,7 @@ from frontend.integrated_computation_runtime import (
     _index_value,
     _trace_env,
     call_relation,
+    call_string,
 )
 from frontend.reason_object_runtime import ReasonObjectRuntimeError, call_ruo, load_reason_object
 from frontend.reasoning_reference import ReasoningReferenceError, call_reasoning
@@ -396,6 +397,9 @@ def _eval_expr(node: dict[str, Any], env: dict[str, Any], ctx: _Context, call_de
     if op == "call_relation":
         arguments = [_eval_expr(argument, env, ctx, call_depth) for argument in node["arguments"]]
         return call_relation(node["function_id"], *arguments)
+    if op == "call_string":
+        arguments = [_eval_expr(argument, env, ctx, call_depth) for argument in node["arguments"]]
+        return call_string(node["function_id"], *arguments)
     if op == "call_vision":
         arguments = [_eval_expr(argument, env, ctx, call_depth) for argument in node["arguments"]]
         return ctx.vision_runtime.call(node["function_id"], *arguments)
@@ -415,6 +419,12 @@ def _eval_expr(node: dict[str, Any], env: dict[str, Any], ctx: _Context, call_de
         import copy
 
         return [*collection, copy.deepcopy(item)]
+    if op == "call_array_concat":
+        left = _eval_expr(node["left"], env, ctx, call_depth)
+        right = _eval_expr(node["right"], env, ctx, call_depth)
+        if not isinstance(left, list) or not isinstance(right, list):
+            raise IntegratedRuntimeError("RT-CALL-006", "array.concat arguments must be arrays")
+        return [*left, *right]
     if op == "call_cast":
         argument = _eval_expr(node["argument"], env, ctx, call_depth)
         if isinstance(argument, bool) or not isinstance(argument, (int, float)):

--- a/frontend/computation_ir/lowering.py
+++ b/frontend/computation_ir/lowering.py
@@ -78,6 +78,7 @@ from frontend.language_surface.nodes import (
     WildcardPatternNode,
 )
 from frontend.relation.integration import relation_call_name
+from frontend.string.integration import string_call_name
 from frontend.tensor.integration import tensor_call_name
 from frontend.tensor.optimizers import optimizer_call_name
 from frontend.vision.integration import vision_call_name
@@ -821,6 +822,13 @@ def _lower_call(value: CallExpressionNode, declared_functions: _Scope) -> dict[s
             "function_id": relation_function,
             "arguments": [_lower_expression(argument, declared_functions) for argument in value.arguments],
         }
+    string_function = string_call_name(value)
+    if string_function is not None:
+        return {
+            "op": "call_string",
+            "function_id": string_function,
+            "arguments": [_lower_expression(argument, declared_functions) for argument in value.arguments],
+        }
     if (
         isinstance(value.callee, MemberAccessNode)
         and isinstance(value.callee.object, IdentifierNode)
@@ -833,6 +841,19 @@ def _lower_call(value: CallExpressionNode, declared_functions: _Scope) -> dict[s
             "op": "call_array_append",
             "collection": _lower_expression(value.arguments[0], declared_functions),
             "item": _lower_expression(value.arguments[1], declared_functions),
+        }
+    if (
+        isinstance(value.callee, MemberAccessNode)
+        and isinstance(value.callee.object, IdentifierNode)
+        and value.callee.object.name == "array"
+        and value.callee.member == "concat"
+    ):
+        if len(value.arguments) != 2:
+            raise LoweringError("IR-LOWER-014", "array.concat expects two arguments")
+        return {
+            "op": "call_array_concat",
+            "left": _lower_expression(value.arguments[0], declared_functions),
+            "right": _lower_expression(value.arguments[1], declared_functions),
         }
     if (
         isinstance(value.callee, IdentifierNode)

--- a/frontend/computation_ir/optimizer.py
+++ b/frontend/computation_ir/optimizer.py
@@ -278,6 +278,8 @@ def _expr_is_pure_function_body(
         "call_relation",
         "call_reasoning",
         "call_array_append",
+        "call_array_concat",
+        "call_string",
     }:
         return False
     return all(
@@ -534,6 +536,10 @@ def _fold_expr(expr: dict[str, Any]) -> dict[str, Any]:
         return {**expr, "arguments": [_fold_expr(argument) for argument in expr["arguments"]]}
     if op == "call_array_append":
         return {**expr, "collection": _fold_expr(expr["collection"]), "item": _fold_expr(expr["item"])}
+    if op == "call_array_concat":
+        return {**expr, "left": _fold_expr(expr["left"]), "right": _fold_expr(expr["right"])}
+    if op == "call_string":
+        return {**expr, "arguments": [_fold_expr(argument) for argument in expr["arguments"]]}
     if op == "call_function":
         return {**expr, "arguments": [_fold_expr(argument) for argument in expr["arguments"]]}
     if op == "call_cast":
@@ -812,13 +818,17 @@ def _collect_reads(expr: dict[str, Any], out: set[str]) -> None:
     if op == "member":
         _collect_reads(expr["object"], out)
         return
-    if op in ("call_tensor", "call_vision", "call_ruo", "call_optimizer", "call_relation", "call_reasoning", "call_function"):
+    if op in ("call_tensor", "call_vision", "call_ruo", "call_optimizer", "call_relation", "call_string", "call_reasoning", "call_function"):
         for argument in expr["arguments"]:
             _collect_reads(argument, out)
         return
     if op == "call_array_append":
         _collect_reads(expr["collection"], out)
         _collect_reads(expr["item"], out)
+        return
+    if op == "call_array_concat":
+        _collect_reads(expr["left"], out)
+        _collect_reads(expr["right"], out)
         return
     if op == "call_cast":
         _collect_reads(expr["argument"], out)
@@ -851,10 +861,20 @@ def _is_side_effect_free(expr: dict[str, Any]) -> bool:
         # Array<Struct> value (see frontend/relation/integration.py) --
         # no I/O or mutation.
         return all(_is_side_effect_free(argument) for argument in expr["arguments"])
+    if op == "call_string":
+        # Every `string.*` function is a pure transformation over its
+        # String/Int/Float/Array<String> arguments (see
+        # frontend/string/integration.py) -- no I/O or mutation, though
+        # `string.slice` can still raise STR-004 out of range, so a call
+        # is only side-effect-*free* (safe to drop if unused), not
+        # necessarily exception-free.
+        return all(_is_side_effect_free(argument) for argument in expr["arguments"])
     if op == "call_function":
         return False  # a user function's body may call tensor.save; conservative
     if op == "call_array_append":
         return _is_side_effect_free(expr["collection"]) and _is_side_effect_free(expr["item"])
+    if op == "call_array_concat":
+        return _is_side_effect_free(expr["left"]) and _is_side_effect_free(expr["right"])
     if op == "call_cast":
         return _is_side_effect_free(expr["argument"])
     if op == "optional_some":
@@ -933,7 +953,7 @@ def _reads_name(expr: dict[str, Any], name: str) -> bool:
 
 def _is_cse_eligible(expr: dict[str, Any]) -> bool:
     op = expr.get("op")
-    if op in ("call_tensor", "call_vision", "call_ruo", "call_optimizer", "call_relation", "call_reasoning", "call_function", "call_array_append"):
+    if op in ("call_tensor", "call_vision", "call_ruo", "call_optimizer", "call_relation", "call_string", "call_reasoning", "call_function", "call_array_append", "call_array_concat"):
         return False  # never dedupe calls: see module docstring
     if op == "const" or op == "local":
         return True

--- a/frontend/computation_ir/schema.py
+++ b/frontend/computation_ir/schema.py
@@ -54,6 +54,8 @@ EXPRESSION_OPS = (
     "call_relation",
     "call_reasoning",
     "call_array_append",
+    "call_array_concat",
+    "call_string",
     "call_function",
     "call_cast",
     "enum_value",

--- a/frontend/integrated_computation_runtime.py
+++ b/frontend/integrated_computation_runtime.py
@@ -74,6 +74,7 @@ from frontend.language_surface.nodes import (
     WildcardPatternNode,
 )
 from frontend.relation.integration import relation_call_name
+from frontend.string.integration import string_call_name
 from frontend.reason_object_runtime import (
     ReasonObjectRuntimeError,
     call_ruo,
@@ -326,6 +327,90 @@ def call_relation(function_id: str, *args: Any) -> Any:
         except TypeError as error:
             raise IntegratedRuntimeError("REL-006", f"Relation field is not orderable: {error}") from error
     raise IntegratedRuntimeError("REL-001", f"unknown Relation function: {function_id}")
+
+
+_STRING_ARGUMENT_COUNTS: dict[str, int] = {
+    "string.concat": 2,
+    "string.join": 2,
+    "string.length": 1,
+    "string.from_int": 1,
+    "string.from_float": 1,
+    "string.slice": 3,
+}
+
+
+def _as_string(value: Any, function_id: str) -> str:
+    if isinstance(value, str):
+        return value
+    raise IntegratedRuntimeError("STR-003", f"{function_id} argument must be String")
+
+
+def _as_int(value: Any, function_id: str) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise IntegratedRuntimeError("STR-003", f"{function_id} argument must be Int")
+
+
+def format_float(value: float) -> str:
+    """Canonical `Float -> String` text, shared with the IR interpreter and
+    matched byte-for-byte by the Rust VM's `string_dispatch::from_float`.
+
+    Always includes a decimal point (`2.0`, not `2`) so a formatted Float
+    never looks like an Int. Deliberately scoped to the normal range: both
+    `repr()` here and Rust's `{}` Display use a shortest-round-trip digit
+    algorithm that agrees digit-for-digit for ordinary values, but Python
+    switches to scientific notation and Rust never does, so extreme
+    magnitudes (roughly outside 1e-4..1e16) are not guaranteed to format
+    identically between the two backends -- not a concern for this
+    minimal standard library, which has no other floating-point formatting
+    controls (precision, scientific notation, locale) to begin with.
+    """
+    text = repr(value)
+    return text if "." in text or "e" in text or "n" in text else f"{text}.0"
+
+
+def call_string(function_id: str, *args: Any) -> Any:
+    """Dispatch a `string.*` function (Phase 2 "String標準ライブラリ").
+
+    A plain module-level function, mirroring `call_relation`: every
+    `string.*` function is pure, with no Tensor backend or persistent
+    state involved.
+    """
+    if function_id not in _STRING_ARGUMENT_COUNTS:
+        raise IntegratedRuntimeError("STR-001", f"unknown String function: {function_id}")
+    expected = _STRING_ARGUMENT_COUNTS[function_id]
+    if len(args) != expected:
+        raise IntegratedRuntimeError(
+            "STR-002",
+            f"String function argument count mismatch: {function_id} expects {expected}",
+        )
+    if function_id == "string.concat":
+        a, b = args
+        return _as_string(a, function_id) + _as_string(b, function_id)
+    if function_id == "string.join":
+        separator, values = args
+        separator = _as_string(separator, function_id)
+        if not isinstance(values, list):
+            raise IntegratedRuntimeError("STR-003", "string.join second argument must be Array<String>")
+        return separator.join(_as_string(item, function_id) for item in values)
+    if function_id == "string.length":
+        return len(_as_string(args[0], function_id))
+    if function_id == "string.from_int":
+        return str(_as_int(args[0], function_id))
+    if function_id == "string.from_float":
+        value = args[0]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise IntegratedRuntimeError("STR-003", "string.from_float argument must be Float")
+        return format_float(float(value))
+    if function_id == "string.slice":
+        value, start, end = args
+        value = _as_string(value, function_id)
+        start = _as_int(start, function_id)
+        end = _as_int(end, function_id)
+        if start < 0 or end < start or end > len(value):
+            raise IntegratedRuntimeError("STR-004", f"string.slice bounds out of range: {start}..{end}")
+        return value[start:end]
+    raise IntegratedRuntimeError("STR-001", f"unknown String function: {function_id}")
 
 
 @dataclass
@@ -932,6 +1017,16 @@ def _expression(
                 for argument in value.arguments
             ]
             return call_relation(relation_function, *arguments)
+        string_function = string_call_name(value)
+        if string_function is not None:
+            arguments = [
+                _expression(
+                    argument, env, runtime, vision_runtime,
+                    functions, max_call_depth, call_depth,
+                )
+                for argument in value.arguments
+            ]
+            return call_string(string_function, *arguments)
         if (
             isinstance(value.callee, MemberAccessNode)
             and isinstance(value.callee.object, IdentifierNode)
@@ -955,6 +1050,34 @@ def _expression(
                     "RT-CALL-002", "array.append first argument must be an array"
                 )
             return [*collection, copy.deepcopy(item)]
+        if (
+            isinstance(value.callee, MemberAccessNode)
+            and isinstance(value.callee.object, IdentifierNode)
+            and value.callee.object.name == "array"
+            and value.callee.member == "concat"
+        ):
+            if len(value.arguments) != 2:
+                raise IntegratedRuntimeError(
+                    "RT-CALL-006", "array.concat expects two arguments"
+                )
+            left = _expression(
+                value.arguments[0], env, runtime, vision_runtime,
+                functions, max_call_depth, call_depth,
+            )
+            right = _expression(
+                value.arguments[1], env, runtime, vision_runtime,
+                functions, max_call_depth, call_depth,
+            )
+            if not isinstance(left, list) or not isinstance(right, list):
+                raise IntegratedRuntimeError(
+                    "RT-CALL-006", "array.concat arguments must be arrays"
+                )
+            # Both sides are elements already living inside an array (unlike
+            # array.append's bare `item`, which needs a deep copy so the new
+            # array doesn't alias a plain local's value) -- a new list
+            # container with the same element identities, matching Rust's
+            # `Vec::clone()` (an `Rc`-bump per element, not a deep clone).
+            return [*left, *right]
         if (
             isinstance(value.callee, IdentifierNode)
             and value.callee.name in {"float", "int"}

--- a/frontend/language_surface/validation.py
+++ b/frontend/language_surface/validation.py
@@ -22,6 +22,11 @@ from frontend.relation.integration import (
     relation_call_name,
     validate_relation_call,
 )
+from frontend.string.integration import (
+    StringSemanticError,
+    string_call_name,
+    validate_string_call,
+)
 from frontend.vision.integration import (
     VisionSemanticError,
     validate_vision_call,
@@ -1643,6 +1648,14 @@ def _validate_calculation_expression(
                 for argument in value.arguments:
                     visit(argument)
                 return
+            if string_call_name(value) is not None:
+                try:
+                    validate_string_call(value)
+                except StringSemanticError as error:
+                    raise SurfaceValidationError(str(error)) from error
+                for argument in value.arguments:
+                    visit(argument)
+                return
             if _ruo_call_name(value) is not None:
                 _validate_ruo_call(value)
                 for argument in value.arguments:
@@ -1763,10 +1776,49 @@ def _array_call_name(value: CallExpressionNode) -> str | None:
 
 def _validate_array_call(value: CallExpressionNode) -> None:
     method = _array_call_name(value)
-    if method != "append":
+    if method not in ("append", "concat"):
         raise SurfaceValidationError("COLL-001 unknown array standard function")
     if len(value.arguments) != 2:
-        raise SurfaceValidationError("COLL-001 array.append argument count mismatch")
+        raise SurfaceValidationError(f"COLL-001 array.{method} argument count mismatch")
+
+
+def _string_call_type(
+    name: str, value: CallExpressionNode, symbols: dict[str, Any], bindings: dict[str, Any]
+) -> Any:
+    def argument_type(index: int) -> Any:
+        argument = value.arguments[index]
+        expr = argument.expression if isinstance(argument, ExpressionNode) else argument
+        return _expression_type(expr, symbols, bindings)
+
+    string_type = PrimitiveTypeNode(PrimitiveKind.STRING)
+    int_type = PrimitiveTypeNode(PrimitiveKind.INT)
+    if name == "string.concat":
+        _require_type_equal(string_type, argument_type(0), "STR-003 string.concat expects String")
+        _require_type_equal(string_type, argument_type(1), "STR-003 string.concat expects String")
+        return string_type
+    if name == "string.join":
+        _require_type_equal(string_type, argument_type(0), "STR-003 string.join separator must be String")
+        _require_type_equal(
+            ArrayTypeNode(string_type), argument_type(1), "STR-003 string.join values must be Array<String>"
+        )
+        return string_type
+    if name == "string.length":
+        _require_type_equal(string_type, argument_type(0), "STR-003 string.length expects String")
+        return int_type
+    if name == "string.from_int":
+        _require_type_equal(int_type, argument_type(0), "STR-003 string.from_int expects Int")
+        return string_type
+    if name == "string.from_float":
+        _require_type_equal(
+            PrimitiveTypeNode(PrimitiveKind.FLOAT), argument_type(0), "STR-003 string.from_float expects Float"
+        )
+        return string_type
+    if name == "string.slice":
+        _require_type_equal(string_type, argument_type(0), "STR-003 string.slice expects String")
+        _require_type_equal(int_type, argument_type(1), "STR-003 string.slice start must be Int")
+        _require_type_equal(int_type, argument_type(2), "STR-003 string.slice end must be Int")
+        return string_type
+    raise SurfaceValidationError(f"STR-001 unknown String function: {name}")
 
 
 def _validate_ruo_call(value: CallExpressionNode) -> None:
@@ -2108,6 +2160,35 @@ def _expression_type(
                 "COLL-003 array.append element type mismatch",
             )
             return collection_type
+        if _array_call_name(value) == "concat":
+            if len(value.arguments) != 2:
+                raise SurfaceValidationError(
+                    "COLL-001 array.concat argument count mismatch"
+                )
+            left_type = _expression_type(
+                value.arguments[0].expression
+                if isinstance(value.arguments[0], ExpressionNode)
+                else value.arguments[0],
+                symbols,
+                bindings,
+            )
+            right_type = _expression_type(
+                value.arguments[1].expression
+                if isinstance(value.arguments[1], ExpressionNode)
+                else value.arguments[1],
+                symbols,
+                bindings,
+            )
+            if not isinstance(left_type, ArrayTypeNode):
+                raise SurfaceValidationError(
+                    "COLL-002 array.concat first argument must be an array"
+                )
+            _require_type_equal(
+                left_type,
+                right_type,
+                "COLL-003 array.concat argument type mismatch",
+            )
+            return left_type
         if tensor_call_name(value) is not None:
             try:
                 validate_tensor_call(value)
@@ -2166,6 +2247,13 @@ def _expression_type(
             if not isinstance(rows_type, ArrayTypeNode):
                 raise SurfaceValidationError("REL-004 Relation function requires Array<Struct>")
             return rows_type
+        string_function = string_call_name(value)
+        if string_function is not None:
+            try:
+                validate_string_call(value)
+            except StringSemanticError as error:
+                raise SurfaceValidationError(str(error)) from error
+            return _string_call_type(string_function, value, symbols, bindings)
         if vision_call_name(value) is not None:
             try:
                 validate_vision_call(value)

--- a/frontend/string/__init__.py
+++ b/frontend/string/__init__.py
@@ -1,0 +1,5 @@
+"""The `string.*` namespace: Phase 2 string standard library.
+
+See `frontend/string/integration.py`'s module docstring for the full
+rationale (why a namespaced function set rather than extending `+`).
+"""

--- a/frontend/string/integration.py
+++ b/frontend/string/integration.py
@@ -1,0 +1,68 @@
+"""Language-to-runtime integration for the `string.*` namespace.
+
+Phase 2 of the recommended fix plan ("String／Collection標準ライブラリ"):
+extending `+` to strings would make the existing numeric-only arithmetic
+type rule (`TYPE-V004`) ambiguous, so string concatenation and the other
+minimal string operations get an explicit namespace instead, mirroring
+how `relation.*`/`tensor.*`/`optimizer.*` already work.
+
+Minimal set: `string.concat(a, b)`, `string.join(separator, values)`,
+`string.length(value)`, `string.from_int(value)`, `string.from_float(value)`,
+`string.slice(value, start, end)`. Every argument is an ordinary
+expression (unlike `relation.*`'s field-name arguments, nothing here
+needs to be a compile-time string literal).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from frontend.language_surface.nodes import CallExpressionNode, ExpressionNode, IdentifierNode, MemberAccessNode
+
+# name -> exact argument count.
+STRING_SIGNATURES: dict[str, int] = {
+    "string.concat": 2,  # a, b
+    "string.join": 2,  # separator, values
+    "string.length": 1,  # value
+    "string.from_int": 1,  # value
+    "string.from_float": 1,  # value
+    "string.slice": 3,  # value, start, end
+}
+
+
+class StringSemanticError(ValueError):
+    """Stable semantic diagnostic raised before Reason IR lowering."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(f"{code} {message}")
+
+
+def string_call_name(value: Any) -> str | None:
+    """Resolve ``string.name(...)`` without treating ``string`` as a module."""
+    value = value.expression if isinstance(value, ExpressionNode) else value
+    if not isinstance(value, CallExpressionNode):
+        return None
+    callee = value.callee
+    if (
+        isinstance(callee, MemberAccessNode)
+        and isinstance(callee.object, IdentifierNode)
+        and callee.object.name == "string"
+    ):
+        return f"string.{callee.member}"
+    return None
+
+
+def validate_string_call(value: CallExpressionNode) -> None:
+    name = string_call_name(value)
+    if name is None:
+        return
+    if name not in STRING_SIGNATURES:
+        raise StringSemanticError("STR-001", f"unknown String function: {name}")
+    expected = STRING_SIGNATURES[name]
+    if len(value.arguments) != expected:
+        raise StringSemanticError(
+            "STR-002",
+            f"String function argument count mismatch: {name} expects {expected}",
+        )


### PR DESCRIPTION
## Summary
- Adds the minimal `string.*` standard library (`concat`/`join`/`length`/`from_int`/`from_float`/`slice`) plus `array.concat`, alongside the existing `array.append`. Follows the `relation.*` namespace pattern throughout: a new `frontend/string/integration.py` resolver + validator, IR lowering to a `call_string` op, a `call_string` function shared by the AST oracle and the Python IR interpreter, and a Rust `string_dispatch.rs` mirroring `relation_dispatch.rs`.
- `+` stays numeric-only (`TYPE-V004`) rather than being extended to strings, per the plan's rationale: a namespaced function set keeps the arithmetic type rule unambiguous.
- `string.from_float` uses a canonical Float→String format chosen so Python and Rust agree byte-for-byte in the normal range (documented limitation for extreme magnitudes, where Python's `repr()` switches to scientific notation and Rust's `Display` never does).
- Learned from the Phase 1 optimizer bug: every new `call_string`/`call_array_concat` shape was threaded through `optimizer.py`'s reachability-adjacent passes explicitly, since `call_string`'s arguments hold reads that dead-code elimination must see and `string.slice` can raise `STR-004`.

**Base note:** stacked on `claude/reasonscript-phase1-enum-optional-match` (#23) — these two phases touch overlapping files but are otherwise independent. This PR's diff will shrink to just the Phase 2 delta once #23 merges.

## Test plan
- [x] `pytest computation_ir_tests/` — 214 passed (23 new: differential, Rust-parity, surface-validation, and optimizer-regression tests for `string.*`/`array.concat`)
- [x] Full Python suite (`pytest -q`) — 2285 passed (1 pre-existing, unrelated environment failure: missing VS Code extension `node_modules`)
- [x] `cargo test --manifest-path ReasonRuntime/Cargo.toml --workspace` — all green
- [x] `cargo clippy -p reasonscript-computation-ir -p reasonscript-computation-runtime-cli` — no new warnings
- [x] Manual Python↔Rust parity smoke test for all 6 string functions + array.concat, including error paths (`STR-004` on both backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)