### PR TITLE
Add assert/assert_eq and make reason test execute (Phase 3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux desktop dependencies
         run: |
@@ -26,6 +29,9 @@ jobs:
             pkg-config
       - run: python3 -m pip install --upgrade pip
       - run: python3 -m pip install -r requirements-dev.txt
+      - name: Install VS Code extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
       - name: Fetch Rust dependencies
         run: |
           for manifest in */Cargo.toml; do

--- a/ReasonRuntime/crates/computation-ir/src/ir.rs
+++ b/ReasonRuntime/crates/computation-ir/src/ir.rs
@@ -329,6 +329,19 @@ pub enum Expr {
         #[serde(default)]
         source_span: Option<serde_json::Value>,
     },
+    #[serde(rename = "assert")]
+    Assert {
+        condition: Box<Expr>,
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
+    #[serde(rename = "assert_eq")]
+    AssertEq {
+        actual: Box<Expr>,
+        expected: Box<Expr>,
+        #[serde(default)]
+        source_span: Option<serde_json::Value>,
+    },
 }
 
 impl Expr {
@@ -357,7 +370,9 @@ impl Expr {
             | Expr::CallCast { source_span, .. }
             | Expr::EnumValue { source_span, .. }
             | Expr::OptionalSome { source_span, .. }
-            | Expr::OptionalNone { source_span, .. } => source_span.as_ref(),
+            | Expr::OptionalNone { source_span, .. }
+            | Expr::Assert { source_span, .. }
+            | Expr::AssertEq { source_span, .. } => source_span.as_ref(),
         }
     }
 }

--- a/ReasonRuntime/crates/computation-ir/src/vm.rs
+++ b/ReasonRuntime/crates/computation-ir/src/vm.rs
@@ -1000,6 +1000,34 @@ impl<'a> Vm<'a> {
                 Ok(Value::Optional(Some(Box::new(inner))))
             }
             Expr::OptionalNone { .. } => Ok(Value::Optional(None)),
+            Expr::Assert { condition, .. } => {
+                match self.eval_expr(condition, env, call_depth)? {
+                    Value::Bool(true) => Ok(Value::Null),
+                    Value::Bool(false) => {
+                        Err(RuntimeError::new("TEST-ASSERT-001", "assertion failed"))
+                    }
+                    other => Err(RuntimeError::new(
+                        "RT-TYPE-001",
+                        format!("assert() argument must be Bool, got {}", other.type_name()),
+                    )),
+                }
+            }
+            Expr::AssertEq { actual, expected, .. } => {
+                let _guard = TempRootGuard::new(self);
+                let actual_value = self.eval_expr(actual, env, call_depth)?;
+                self.push_temporary_root(actual_value.clone());
+                let expected_value = self.eval_expr(expected, env, call_depth)?;
+                if actual_value == expected_value {
+                    Ok(Value::Null)
+                } else {
+                    Err(RuntimeError::new(
+                        "TEST-ASSERT-001",
+                        format!(
+                            "assertion failed: expected {expected_value}, got {actual_value}"
+                        ),
+                    ))
+                }
+            }
         }
     }
 

--- a/computation_ir_tests/test_computation_ir_assertions.py
+++ b/computation_ir_tests/test_computation_ir_assertions.py
@@ -1,0 +1,216 @@
+"""`assert`/`assert_eq`: Phase 3's "実行型テスト機構" language-level assertion
+primitives.
+
+Both are bare global builtins (not a namespace), recognized the same way
+as the `float`/`int` scalar casts: a same-named user `fn` shadows the
+builtin. A failed assertion raises `TEST-ASSERT-001` on both backends --
+this is the diagnostic code `toolchain/runner_cmd.py`'s `reason test`
+uses to tell a genuine assertion failure apart from an unrelated runtime
+error.
+
+Same differential pattern as every other `computation_ir_tests` parity
+suite: lower once, run through both `interpret_program` and the Rust CLI,
+assert `calculation_results` / error codes agree exactly. Rust
+comparisons are skipped (not failed) if the binary isn't built.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from frontend.computation_ir import interpret_program, lower_program, validate_program
+from frontend.computation_ir.rust_bridge import find_binary, run_ir
+from frontend.integrated_computation_runtime import IntegratedRuntimeError, LoopLimitError
+from frontend.language_surface import parse
+from frontend.language_surface.parser import SurfaceSyntaxError
+
+_BINARY = find_binary()
+
+
+def _lower(source: str):
+    return lower_program(parse(source))
+
+
+def _python_outcome(source: str):
+    ir = _lower(source)
+    try:
+        result = interpret_program(ir)
+    except (IntegratedRuntimeError, LoopLimitError) as error:
+        return None, getattr(error, "code", None)
+    return dict(result.calculation_results), None
+
+
+def _rust_outcome(source: str):
+    ir = _lower(source)
+    outcome = run_ir(ir, binary=_BINARY)
+    if outcome.ok:
+        return outcome.calculation_results, None
+    return None, outcome.error_code
+
+
+class AssertionParityMixin:
+    def assert_parity(self, source: str):
+        ir = _lower(source)
+        self.assertEqual(validate_program(ir), [])
+        python_results, python_error = _python_outcome(source)
+        if _BINARY is not None:
+            rust_results, rust_error = _rust_outcome(source)
+            self.assertEqual(python_error, rust_error, f"error code mismatch for:\n{source}")
+            if python_error is None:
+                self.assertEqual(python_results, rust_results, f"result mismatch for:\n{source}")
+        return python_results, python_error
+
+
+class AssertTests(AssertionParityMixin, unittest.TestCase):
+    def test_true_condition_passes_silently(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    assert(1 == 1)
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 1)
+
+    def test_false_condition_reports_test_assert_001_on_both_backends(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    assert(1 == 2)
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "TEST-ASSERT-001")
+
+    def test_unused_assert_result_still_executes(self):
+        # The whole point of Phase 3: an assert whose (null) result is
+        # never read must still run -- dead-code elimination silently
+        # dropping it would make every assertion a no-op.
+        _, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    assert(false)
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "TEST-ASSERT-001")
+
+
+class AssertEqTests(AssertionParityMixin, unittest.TestCase):
+    def test_matching_values_pass_silently(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    assert_eq(2 + 2, 4)
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 1)
+
+    def test_mismatched_int_values_report_test_assert_001(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    assert_eq(2 + 2, 5)
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "TEST-ASSERT-001")
+
+    def test_mismatched_string_values_report_test_assert_001(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    assert_eq(string.concat("a", "b"), "ac")
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "TEST-ASSERT-001")
+
+    def test_matching_struct_values_pass_silently(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                struct Point {
+                    x: int
+                    y: int
+                }
+                calculation Answer {
+                    let a = Point { x: 1, y: 2 }
+                    let b = Point { x: 1, y: 2 }
+                    assert_eq(a, b)
+                    result = 1
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 1)
+
+
+class SurfaceValidationTests(unittest.TestCase):
+    """`assert`/`assert_eq` type errors are caught before lowering,
+    matching how the `float`/`int` scalar casts are validated."""
+
+    def test_assert_rejects_non_bool_condition(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        assert(1)
+                        result = 1
+                    }
+                }
+                """
+            )
+
+    def test_assert_argument_count_mismatch_is_rejected(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        assert(true, false)
+                        result = 1
+                    }
+                }
+                """
+            )
+
+    def test_assert_eq_rejects_mismatched_types(self):
+        with self.assertRaises(SurfaceSyntaxError):
+            parse(
+                """
+                module M {
+                    calculation Answer {
+                        assert_eq(1, "1")
+                        result = 1
+                    }
+                }
+                """
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/computation_ir_tests/test_computation_ir_optimizer.py
+++ b/computation_ir_tests/test_computation_ir_optimizer.py
@@ -705,6 +705,90 @@ class StringFunctionsInteractionTests(OptimizerParityMixin, unittest.TestCase):
         self.assertEqual(len(concat_calls), 2)
 
 
+class AssertionOptimizationTests(OptimizerParityMixin, unittest.TestCase):
+    """Phase 3: `assert`/`assert_eq` must never be eliminated as dead code,
+    even though their result is always unused (their entire purpose is
+    the "may raise" side effect, unlike every other namespaced call this
+    optimizer treats as safe-to-drop-if-unused)."""
+
+    def test_unused_assert_survives_dead_code_elimination(self):
+        ir = _lower(
+            """
+            module M {
+                calculation Answer {
+                    assert(1 == 1)
+                    result = 1
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        asserts = [
+            instruction
+            for block in optimized["functions"][0]["blocks"]
+            for instruction in block["instructions"]
+            if instruction.get("op") == "expr" and instruction["expr"].get("op") == "assert"
+        ]
+        self.assertEqual(len(asserts), 1)
+
+    def test_unused_assert_eq_survives_dead_code_elimination(self):
+        ir = _lower(
+            """
+            module M {
+                calculation Answer {
+                    assert_eq(2 + 2, 4)
+                    result = 1
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        asserts = [
+            instruction
+            for block in optimized["functions"][0]["blocks"]
+            for instruction in block["instructions"]
+            if instruction.get("op") == "expr" and instruction["expr"].get("op") == "assert_eq"
+        ]
+        self.assertEqual(len(asserts), 1)
+
+    def test_local_read_only_inside_assert_condition_is_not_eliminated(self):
+        ir = _lower(
+            """
+            module M {
+                calculation Answer {
+                    let flag = true
+                    assert(flag)
+                    result = 1
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        assigns = [
+            instruction
+            for block in optimized["functions"][0]["blocks"]
+            for instruction in block["instructions"]
+            if instruction.get("op") == "assign" and instruction.get("target") == "flag"
+        ]
+        self.assertEqual(len(assigns), 1)
+
+    def test_assertion_pipeline_survives_optimization(self):
+        optimized, results = self.assert_parity(
+            """
+            module M {
+                calculation Answer {
+                    let a = 2 + 2
+                    assert_eq(a, 4)
+                    assert(a > 0)
+                    result = a
+                }
+            }
+            """
+        )
+        self.assertEqual(results["Answer"], 4)
+        del optimized
+
+
 class MatchOptimizationTests(OptimizerParityMixin, unittest.TestCase):
     """Phase 1: the `match` terminator and `enum_value`/`optional_some`/
     `optional_none` expressions must survive every optimizer pass intact.

--- a/frontend/computation_ir/interpreter.py
+++ b/frontend/computation_ir/interpreter.py
@@ -438,6 +438,19 @@ def _eval_expr(node: dict[str, Any], env: dict[str, Any], ctx: _Context, call_de
         return RuntimeOptionalValue(True, _eval_expr(node["value"], env, ctx, call_depth))
     if op == "optional_none":
         return RuntimeOptionalValue(False)
+    if op == "assert":
+        condition = _eval_expr(node["condition"], env, ctx, call_depth)
+        if condition is not True:
+            raise IntegratedRuntimeError("TEST-ASSERT-001", "assertion failed")
+        return None
+    if op == "assert_eq":
+        actual = _eval_expr(node["actual"], env, ctx, call_depth)
+        expected = _eval_expr(node["expected"], env, ctx, call_depth)
+        if actual != expected:
+            raise IntegratedRuntimeError(
+                "TEST-ASSERT-001", f"assertion failed: expected {expected!r}, got {actual!r}"
+            )
+        return None
     raise IRExecutionError("IR-EXEC-003", f"unknown expression op: {op}")
 
 

--- a/frontend/computation_ir/lowering.py
+++ b/frontend/computation_ir/lowering.py
@@ -86,6 +86,7 @@ from frontend.vision.integration import vision_call_name
 from .schema import SCHEMA
 
 _SCALAR_CAST_NAMES = {"float", "int"}
+_ASSERT_NAMES = {"assert", "assert_eq"}
 
 
 class LoweringError(ValueError):
@@ -866,6 +867,25 @@ def _lower_call(value: CallExpressionNode, declared_functions: _Scope) -> dict[s
             "op": "call_cast",
             "name": value.callee.name,
             "argument": _lower_expression(value.arguments[0], declared_functions),
+        }
+    if (
+        isinstance(value.callee, IdentifierNode)
+        and value.callee.name in _ASSERT_NAMES
+        and value.callee.name not in declared_functions.functions
+    ):
+        if value.callee.name == "assert":
+            if len(value.arguments) != 1:
+                raise LoweringError("IR-LOWER-015", "assert() expects exactly one argument")
+            return {
+                "op": "assert",
+                "condition": _lower_expression(value.arguments[0], declared_functions),
+            }
+        if len(value.arguments) != 2:
+            raise LoweringError("IR-LOWER-015", "assert_eq() expects exactly two arguments")
+        return {
+            "op": "assert_eq",
+            "actual": _lower_expression(value.arguments[0], declared_functions),
+            "expected": _lower_expression(value.arguments[1], declared_functions),
         }
     if isinstance(value.callee, IdentifierNode):
         return {

--- a/frontend/computation_ir/optimizer.py
+++ b/frontend/computation_ir/optimizer.py
@@ -280,6 +280,8 @@ def _expr_is_pure_function_body(
         "call_array_append",
         "call_array_concat",
         "call_string",
+        "assert",
+        "assert_eq",
     }:
         return False
     return all(
@@ -550,6 +552,10 @@ def _fold_expr(expr: dict[str, Any]) -> dict[str, Any]:
         return {**expr, "argument": argument}
     if op == "optional_some":
         return {**expr, "value": _fold_expr(expr["value"])}
+    if op == "assert":
+        return {**expr, "condition": _fold_expr(expr["condition"])}
+    if op == "assert_eq":
+        return {**expr, "actual": _fold_expr(expr["actual"]), "expected": _fold_expr(expr["expected"])}
     return expr
 
 
@@ -836,6 +842,13 @@ def _collect_reads(expr: dict[str, Any], out: set[str]) -> None:
     if op == "optional_some":
         _collect_reads(expr["value"], out)
         return
+    if op == "assert":
+        _collect_reads(expr["condition"], out)
+        return
+    if op == "assert_eq":
+        _collect_reads(expr["actual"], out)
+        _collect_reads(expr["expected"], out)
+        return
 
 
 _IMPURE_FUNCTION_IDS = {"tensor.load", "tensor.save"}
@@ -879,6 +892,15 @@ def _is_side_effect_free(expr: dict[str, Any]) -> bool:
         return _is_side_effect_free(expr["argument"])
     if op == "optional_some":
         return _is_side_effect_free(expr["value"])
+    if op in ("assert", "assert_eq"):
+        # Unlike every other namespaced call above, an assert's entire
+        # purpose IS its "may raise" effect, and it is used as a bare,
+        # unused-result statement in the *normal* case (not an edge case
+        # like string.slice's bounds check) -- so, unlike those, this can
+        # never be side-effect-free regardless of its arguments, or dead
+        # local elimination would silently turn every assertion into a
+        # no-op the moment its (always-unused) result isn't read.
+        return False
     if op == "array":
         return all(_is_side_effect_free(item) for item in expr["elements"])
     if op == "struct":
@@ -953,7 +975,7 @@ def _reads_name(expr: dict[str, Any], name: str) -> bool:
 
 def _is_cse_eligible(expr: dict[str, Any]) -> bool:
     op = expr.get("op")
-    if op in ("call_tensor", "call_vision", "call_ruo", "call_optimizer", "call_relation", "call_string", "call_reasoning", "call_function", "call_array_append", "call_array_concat"):
+    if op in ("call_tensor", "call_vision", "call_ruo", "call_optimizer", "call_relation", "call_string", "call_reasoning", "call_function", "call_array_append", "call_array_concat", "assert", "assert_eq"):
         return False  # never dedupe calls: see module docstring
     if op == "const" or op == "local":
         return True

--- a/frontend/computation_ir/schema.py
+++ b/frontend/computation_ir/schema.py
@@ -61,6 +61,8 @@ EXPRESSION_OPS = (
     "enum_value",
     "optional_some",
     "optional_none",
+    "assert",
+    "assert_eq",
 )
 
 INSTRUCTION_OPS = (

--- a/frontend/integrated_computation_runtime.py
+++ b/frontend/integrated_computation_runtime.py
@@ -1096,6 +1096,41 @@ def _expression(
                     "RT-CALL-005", f"{value.callee.name}() argument must be Int or Float"
                 )
             return float(argument) if value.callee.name == "float" else int(argument)
+        if (
+            isinstance(value.callee, IdentifierNode)
+            and value.callee.name in {"assert", "assert_eq"}
+            and value.callee.name not in functions
+        ):
+            if value.callee.name == "assert":
+                if len(value.arguments) != 1:
+                    raise IntegratedRuntimeError(
+                        "RT-CALL-002", "assert() expects exactly one argument"
+                    )
+                condition = _expression(
+                    value.arguments[0], env, runtime, vision_runtime,
+                    functions, max_call_depth, call_depth,
+                )
+                if condition is not True:
+                    raise IntegratedRuntimeError("TEST-ASSERT-001", "assertion failed")
+                return None
+            if len(value.arguments) != 2:
+                raise IntegratedRuntimeError(
+                    "RT-CALL-002", "assert_eq() expects exactly two arguments"
+                )
+            actual = _expression(
+                value.arguments[0], env, runtime, vision_runtime,
+                functions, max_call_depth, call_depth,
+            )
+            expected = _expression(
+                value.arguments[1], env, runtime, vision_runtime,
+                functions, max_call_depth, call_depth,
+            )
+            if actual != expected:
+                raise IntegratedRuntimeError(
+                    "TEST-ASSERT-001",
+                    f"assertion failed: expected {expected!r}, got {actual!r}",
+                )
+            return None
         if isinstance(value.callee, (IdentifierNode, QualifiedIdentifierNode)):
             function_ref = (
                 functions.get(value.callee.name)

--- a/frontend/language_surface/validation.py
+++ b/frontend/language_surface/validation.py
@@ -1763,6 +1763,26 @@ def _scalar_cast_name(value: CallExpressionNode, symbols: dict[str, Any]) -> str
     return None
 
 
+_ASSERT_NAMES = {"assert", "assert_eq"}
+
+
+def _assert_call_name(value: CallExpressionNode, symbols: dict[str, Any]) -> str | None:
+    """Resolve a bare `assert(...)`/`assert_eq(...)` call, mirroring `_scalar_cast_name`.
+
+    Phase 3 ("実行型テスト機構"): both are reserved global builtins, not a
+    namespace, exactly like `float`/`int` -- and, like those, a same-named
+    user `fn` declaration shadows the builtin rather than being rejected.
+    """
+    callee = value.callee
+    if (
+        isinstance(callee, IdentifierNode)
+        and callee.name in _ASSERT_NAMES
+        and not isinstance(symbols.get(callee.name), FunctionDeclarationNode)
+    ):
+        return callee.name
+    return None
+
+
 def _array_call_name(value: CallExpressionNode) -> str | None:
     callee = value.callee
     if (
@@ -2282,6 +2302,53 @@ def _expression_type(
             return PrimitiveTypeNode(
                 PrimitiveKind.FLOAT if cast_name == "float" else PrimitiveKind.INT
             )
+        assert_name = _assert_call_name(value, symbols)
+        if assert_name is not None:
+            null_type = PrimitiveTypeNode(PrimitiveKind.NULL)
+            if assert_name == "assert":
+                if len(value.arguments) != 1:
+                    raise SurfaceValidationError(
+                        "TEST-ASSERT-002 assert() expects exactly one argument"
+                    )
+                condition_argument = value.arguments[0]
+                condition_expression = (
+                    condition_argument.expression
+                    if isinstance(condition_argument, ExpressionNode)
+                    else condition_argument
+                )
+                condition_type = _expression_type(condition_expression, symbols, bindings)
+                if condition_type is not _UNKNOWN_TYPE and condition_type != PrimitiveTypeNode(
+                    PrimitiveKind.BOOL
+                ):
+                    raise SurfaceValidationError(
+                        "TEST-ASSERT-003 assert() argument must be Bool"
+                    )
+                return null_type
+            if len(value.arguments) != 2:
+                raise SurfaceValidationError(
+                    "TEST-ASSERT-002 assert_eq() expects exactly two arguments"
+                )
+            actual_argument, expected_argument = value.arguments
+            actual_type = _expression_type(
+                actual_argument.expression
+                if isinstance(actual_argument, ExpressionNode)
+                else actual_argument,
+                symbols,
+                bindings,
+            )
+            expected_type = _expression_type(
+                expected_argument.expression
+                if isinstance(expected_argument, ExpressionNode)
+                else expected_argument,
+                symbols,
+                bindings,
+            )
+            _require_type_equal(
+                actual_type,
+                expected_type,
+                "TEST-ASSERT-003 assert_eq() arguments must have the same type",
+            )
+            return null_type
         if isinstance(value.callee, IdentifierNode):
             if value.callee.name == _CURRENT_FUNCTION:
                 raise SurfaceValidationError("FN-007 recursive function calls are rejected")

--- a/toolchain/__main__.py
+++ b/toolchain/__main__.py
@@ -109,7 +109,14 @@ def main() -> int:
 
     if command == "test":
         from toolchain.runner_cmd import run
-        return run(project_root, package=package)
+        return run(
+            project_root,
+            package=package,
+            compile_only="--compile-only" in args[1:],
+            output_format=_option_arg(args[1:], "--format") or "text",
+            filesystem_read="--allow-read" in args[1:],
+            filesystem_write="--allow-write" in args[1:],
+        )
 
     if command == "check":
         from toolchain.check_cmd import run

--- a/toolchain/runner_cmd.py
+++ b/toolchain/runner_cmd.py
@@ -1,19 +1,65 @@
-"""reason test — discover and execute ReasonScript test suites."""
+"""reason test — discover and execute ReasonScript test suites.
+
+Phase 3 ("実行型テスト機構"): a test file that only *compiles* is no
+longer reported as PASS -- every `calculation` in it is actually run
+through the native Rust host (the same `execute_rust_program` path
+`reason run` uses), and `assert`/`assert_eq` failures (`TEST-ASSERT-001`)
+are reported as a distinct category from an unrelated runtime error or a
+compile-time failure. The pre-Phase-3 compile-only behavior is still
+available via `--compile-only`, for callers that only want a fast
+syntax/type check over the test suite without executing it.
+"""
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+from xml.sax.saxutils import escape as _xml_escape
 
 from .manifest import Manifest, ManifestError
 from .pipeline import PipelineError, compile_package_sources, compile_source
+from .runtime_dispatch import RustDispatchError, execute_rust_program
 from .workspace import (
     PackageGraphService,
     WorkspaceError,
     diagnostic_from_workspace_error,
 )
 
+# `RustDispatchError.code`s that mean "this test file couldn't even be
+# turned into executable IR" -- from the test author's point of view this
+# is a compile-time defect (an unsupported language construct), not
+# something that went wrong while running otherwise-valid code.
+_LOWERING_FAILURE_REASONS = {"computation_ir_lowering_unsupported"}
 
-def run(project_root: Path, package: str | None = None) -> int:
+# `RustDispatchError.code`s that mean the whole run can't proceed at all
+# (missing/unbuildable native host) -- reported once, not once per test.
+_INFRASTRUCTURE_REASONS = {"rust_binary_missing"}
+
+
+@dataclass
+class TestOutcome:
+    name: str
+    package: str
+    status: str  # "pass" | "compile_error" | "runtime_error" | "assertion_failure"
+    code: str | None = None
+    message: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "pass"
+
+
+def run(
+    project_root: Path,
+    package: str | None = None,
+    *,
+    compile_only: bool = False,
+    output_format: str = "text",
+    filesystem_read: bool = False,
+    filesystem_write: bool = False,
+) -> int:
     try:
         workspace = PackageGraphService().discover(project_root)
     except WorkspaceError as error:
@@ -23,48 +69,66 @@ def run(project_root: Path, package: str | None = None) -> int:
         print(f"Error:\n\n{error}")
         return 1
 
+    outcomes: list[TestOutcome] = []
     if workspace.is_workspace:
         package_names = (package,) if package is not None else workspace.graph.build_order
-        failures = 0
         for package_name in package_names:
             try:
                 node = workspace.graph.package(package_name)
             except WorkspaceError as error:
                 _print_workspace_error(error)
                 return 1
-            rc = _run_package(node.path)
-            if rc == 3:
-                failures += 1
-            elif rc != 0:
+            package_outcomes, rc = _collect_package(
+                node.path,
+                node.name,
+                compile_only=compile_only,
+                filesystem_read=filesystem_read,
+                filesystem_write=filesystem_write,
+            )
+            if rc == 1:
                 return rc
-        print(f"Workspace tests completed. {len(package_names)} package(s) tested.")
-        return 3 if failures else 0
+            outcomes.extend(package_outcomes)
+        return _report(outcomes, output_format)
 
     if package is not None and package != workspace.default_package.name:
         _print_workspace_error(WorkspaceError(f"unknown package: {package}"))
         return 1
-    return _run_package(workspace.default_package.path)
+    package_outcomes, rc = _collect_package(
+        workspace.default_package.path,
+        workspace.default_package.name,
+        compile_only=compile_only,
+        filesystem_read=filesystem_read,
+        filesystem_write=filesystem_write,
+    )
+    if rc == 1:
+        return rc
+    return _report(package_outcomes, output_format)
 
 
-def _run_package(project_root: Path) -> int:
+def _collect_package(
+    project_root: Path,
+    package_name: str,
+    *,
+    compile_only: bool,
+    filesystem_read: bool,
+    filesystem_write: bool,
+) -> tuple[list[TestOutcome], int]:
     try:
-        Manifest.load(project_root)
+        manifest = Manifest.load(project_root)
     except ManifestError as e:
         print(f"Error:\n\n{e}")
-        return 1
+        return [], 1
 
     tests_dir = project_root / "tests"
     if not tests_dir.exists():
         print("No tests/ directory found.")
-        return 0
+        return [], 0
 
     test_files = sorted(tests_dir.rglob("*.rsn"))
     if not test_files:
         print("No test files found.")
-        return 0
+        return [], 0
 
-    passed: list[str] = []
-    failed: list[tuple[str, str]] = []
     source_files = (
         sorted((project_root / "src").rglob("*.rsn"))
         if (project_root / "src").is_dir()
@@ -74,6 +138,7 @@ def _run_package(project_root: Path) -> int:
         (path.read_text(encoding="utf-8"), path) for path in source_files
     ]
 
+    outcomes: list[TestOutcome] = []
     for test_path in test_files:
         name = test_path.stem
         test_source = test_path.read_text(encoding="utf-8")
@@ -82,26 +147,123 @@ def _run_package(project_root: Path) -> int:
                 line.lstrip().startswith("import ")
                 for line in test_source.splitlines()
             ):
-                compile_package_sources(
+                result = compile_package_sources(
                     [*package_sources, (test_source, test_path)]
                 )
             else:
-                compile_source(test_source, test_path)
-            passed.append(name)
+                result = compile_source(test_source, test_path)
         except PipelineError as e:
-            failed.append((name, f"{e.code}: {e.message}"))
+            outcomes.append(TestOutcome(
+                name, package_name, "compile_error", e.code, e.message,
+            ))
+            continue
 
-    for name in passed:
-        print(f"PASS  {name}")
-    for name, msg in failed:
-        print(f"FAIL  {name}")
-        print(f"      {msg}")
+        if compile_only:
+            outcomes.append(TestOutcome(name, package_name, "pass"))
+            continue
+
+        try:
+            execute_rust_program(
+                result.surface_ast,
+                project_root,
+                filesystem_read,
+                filesystem_write,
+                backend=manifest.backend,
+            )
+        except RustDispatchError as error:
+            if error.reason in _INFRASTRUCTURE_REASONS:
+                print(f"Error:\n\n{error.code}\n\n{error.message}")
+                return [], 1
+            if error.code == "TEST-ASSERT-001":
+                outcomes.append(TestOutcome(
+                    name, package_name, "assertion_failure", error.code, error.message,
+                ))
+            elif error.reason in _LOWERING_FAILURE_REASONS:
+                outcomes.append(TestOutcome(
+                    name, package_name, "compile_error", error.code, error.message,
+                ))
+            else:
+                outcomes.append(TestOutcome(
+                    name, package_name, "runtime_error", error.code, error.message,
+                ))
+            continue
+
+        outcomes.append(TestOutcome(name, package_name, "pass"))
+
+    return outcomes, 0
+
+
+def _report(outcomes: list[TestOutcome], output_format: str) -> int:
+    if output_format == "json":
+        _report_json(outcomes)
+    elif output_format == "junit":
+        _report_junit(outcomes)
+    else:
+        _report_text(outcomes)
+    return 3 if any(not outcome.passed for outcome in outcomes) else 0
+
+
+def _report_text(outcomes: list[TestOutcome]) -> None:
+    passed = [outcome for outcome in outcomes if outcome.passed]
+    failed = [outcome for outcome in outcomes if not outcome.passed]
+    for outcome in passed:
+        print(f"PASS  {outcome.name}")
+    for outcome in failed:
+        print(f"FAIL  {outcome.name} [{outcome.status}]")
+        print(f"      {outcome.code}: {outcome.message}")
 
     print()
     print(f"{len(passed)} passed")
     print(f"{len(failed)} failed")
 
-    return 3 if failed else 0
+
+def _outcome_dict(outcome: TestOutcome) -> dict[str, Any]:
+    return {
+        "name": outcome.name,
+        "package": outcome.package,
+        "status": outcome.status,
+        "code": outcome.code,
+        "message": outcome.message,
+    }
+
+
+def _report_json(outcomes: list[TestOutcome]) -> None:
+    passed = sum(1 for outcome in outcomes if outcome.passed)
+    failed = len(outcomes) - passed
+    print(json.dumps(
+        {
+            "schema": "reasonscript-test-report/1.0",
+            "tests": [_outcome_dict(outcome) for outcome in outcomes],
+            "summary": {"passed": passed, "failed": failed, "total": len(outcomes)},
+        },
+        indent=2,
+    ))
+
+
+def _report_junit(outcomes: list[TestOutcome]) -> None:
+    failed = sum(1 for outcome in outcomes if not outcome.passed)
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<testsuite name="reason-test" tests="{len(outcomes)}" failures="{failed}">',
+    ]
+    for outcome in outcomes:
+        package_attr = _xml_escape(outcome.package)
+        name_attr = _xml_escape(outcome.name)
+        if outcome.passed:
+            lines.append(
+                f'  <testcase classname="{package_attr}" name="{name_attr}"/>'
+            )
+            continue
+        message = _xml_escape(f"{outcome.code}: {outcome.message}")
+        lines.append(
+            f'  <testcase classname="{package_attr}" name="{name_attr}">'
+        )
+        lines.append(
+            f'    <failure message="{message}" type="{_xml_escape(outcome.status)}"/>'
+        )
+        lines.append('  </testcase>')
+    lines.append('</testsuite>')
+    print("\n".join(lines))
 
 
 def _print_workspace_error(error: WorkspaceError) -> None:

--- a/toolchain_phase1_tests/test_toolchain_conformance.py
+++ b/toolchain_phase1_tests/test_toolchain_conformance.py
@@ -1,12 +1,15 @@
 """Toolchain Phase 1 Conformance Tests — TC1-001 through TC1-010."""
 
+import io
 import json
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
+from xml.etree import ElementTree
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -17,6 +20,8 @@ from toolchain.check_cmd import run as check_run
 from toolchain.init_cmd import run as init_run
 from toolchain.manifest import SUPPORTED_BACKENDS, Manifest, ManifestError
 from toolchain.run_cmd import run as run_run
+from toolchain.runner_cmd import TestOutcome as _RunnerTestOutcome
+from toolchain.runner_cmd import _collect_package
 from toolchain.runner_cmd import run as suite_run
 
 _SIMPLE_RSN = """\
@@ -37,6 +42,37 @@ module sample_test {
 }
 """
 
+_ASSERTION_FAIL_RSN = """\
+package hello_world
+module assertion_test {
+    calculation Answer {
+        assert(1 == 2)
+        result = 1
+    }
+}
+"""
+
+_ASSERTION_OK_RSN = """\
+package hello_world
+module assertion_ok_test {
+    calculation Answer {
+        assert_eq(2 + 2, 4)
+        result = 1
+    }
+}
+"""
+
+_RUNTIME_ERROR_RSN = """\
+package hello_world
+module runtime_error_test {
+    calculation Answer {
+        let a = 1
+        let b = 0
+        result = a / b
+    }
+}
+"""
+
 _REASON_TOML = """\
 [package]
 name = "hello_world"
@@ -49,6 +85,26 @@ platform = "0.2"
 [runtime]
 backend = "RuntimeReal"
 """
+
+
+def _collect_only(
+    project_root: Path, *, compile_only: bool = False
+) -> tuple[list[_RunnerTestOutcome], int]:
+    manifest = Manifest.load(project_root)
+    outcomes, rc = _collect_package(
+        project_root,
+        manifest.name,
+        compile_only=compile_only,
+        filesystem_read=False,
+        filesystem_write=False,
+    )
+    if rc != 0:
+        return outcomes, rc
+    # `_collect_package`'s own return code only ever signals an
+    # infrastructure-level failure (bad manifest, missing Rust binary),
+    # not "some test failed" -- that's `_report`'s job, replicated here so
+    # this direct-collection helper matches `suite_run`'s real exit code.
+    return outcomes, (3 if any(not outcome.passed for outcome in outcomes) else 0)
 
 
 class TC1001Init(unittest.TestCase):
@@ -183,6 +239,68 @@ class TC1004Test(unittest.TestCase):
         )
         rc = suite_run(self.tmp)
         self.assertEqual(rc, 3)
+
+    def test_failing_assertion_reports_test_assert_001_and_exit_3(self):
+        # Phase 3 ("実行型テスト機構"): a test file that compiles but
+        # whose assertion fails at runtime must fail the suite -- the
+        # pre-Phase-3 behavior reported this as PASS since only
+        # compilation was checked.
+        (self.tmp / "tests" / "assertion_test.rsn").write_text(_ASSERTION_FAIL_RSN, encoding="utf-8")
+        outcomes, rc = _collect_only(self.tmp)
+        self.assertEqual(rc, 3)
+        failing = next(o for o in outcomes if o.name == "assertion_test")
+        self.assertEqual(failing.status, "assertion_failure")
+        self.assertEqual(failing.code, "TEST-ASSERT-001")
+
+    def test_runtime_error_is_a_distinct_category_from_assertion_failure(self):
+        (self.tmp / "tests" / "runtime_error_test.rsn").write_text(_RUNTIME_ERROR_RSN, encoding="utf-8")
+        outcomes, rc = _collect_only(self.tmp)
+        self.assertEqual(rc, 3)
+        failing = next(o for o in outcomes if o.name == "runtime_error_test")
+        self.assertEqual(failing.status, "runtime_error")
+        self.assertNotEqual(failing.code, "TEST-ASSERT-001")
+
+    def test_passing_assertion_test_still_passes(self):
+        (self.tmp / "tests" / "assertion_ok_test.rsn").write_text(_ASSERTION_OK_RSN, encoding="utf-8")
+        outcomes, rc = _collect_only(self.tmp)
+        self.assertEqual(rc, 0)
+        passing = next(o for o in outcomes if o.name == "assertion_ok_test")
+        self.assertEqual(passing.status, "pass")
+
+    def test_compile_only_flag_does_not_execute(self):
+        # A failing assertion must NOT fail the suite under --compile-only
+        # (the pre-Phase-3 behavior, preserved as an explicit opt-out).
+        (self.tmp / "tests" / "assertion_test.rsn").write_text(_ASSERTION_FAIL_RSN, encoding="utf-8")
+        outcomes, rc = _collect_only(self.tmp, compile_only=True)
+        self.assertEqual(rc, 0)
+        outcome = next(o for o in outcomes if o.name == "assertion_test")
+        self.assertEqual(outcome.status, "pass")
+
+    def test_json_report_contains_every_test_with_its_status(self):
+        (self.tmp / "tests" / "assertion_test.rsn").write_text(_ASSERTION_FAIL_RSN, encoding="utf-8")
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            rc = suite_run(self.tmp, output_format="json")
+        self.assertEqual(rc, 3)
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(report["schema"], "reasonscript-test-report/1.0")
+        names = {test["name"]: test["status"] for test in report["tests"]}
+        self.assertEqual(names["sample_test"], "pass")
+        self.assertEqual(names["assertion_test"], "assertion_failure")
+        self.assertEqual(report["summary"], {"passed": 1, "failed": 1, "total": 2})
+
+    def test_junit_report_is_well_formed_xml(self):
+        (self.tmp / "tests" / "assertion_test.rsn").write_text(_ASSERTION_FAIL_RSN, encoding="utf-8")
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            rc = suite_run(self.tmp, output_format="junit")
+        self.assertEqual(rc, 3)
+        root = ElementTree.fromstring(stdout.getvalue())
+        self.assertEqual(root.tag, "testsuite")
+        self.assertEqual(root.attrib["tests"], "2")
+        self.assertEqual(root.attrib["failures"], "1")
+        failures = root.findall("./testcase/failure")
+        self.assertEqual(len(failures), 1)
 
 
 class TC1005Check(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Adds `assert(condition)`/`assert_eq(actual, expected)` as reserved global builtins (like `float`/`int`), across every layer through the Rust VM. A failed assertion raises `TEST-ASSERT-001` on both backends.
- **Critical optimizer fix**: `assert`/`assert_eq`'s entire purpose is their "may raise" effect, and they're used as a bare, always-unused-result statement in the normal case — `_is_side_effect_free` now returns `False` unconditionally for both, or dead local elimination would silently turn every assertion into a no-op. Verified with a dedicated regression test, learned directly from the Phase 1 optimizer bug in this same area.
- Rewrites `toolchain/runner_cmd.py` (`reason test`): test files are now lowered and **executed** through the same `execute_rust_program` path `reason run` uses, instead of only compiled — "PASS" no longer means merely "this file compiled." Failures are reported in three distinct categories: `compile_error`, `runtime_error`, `assertion_failure` (`TEST-ASSERT-001`). The old compile-only behavior is preserved via `--compile-only`. Adds `--format json` and `--format junit` report output.

**Base note:** stacked on `claude/reasonscript-phase2-string-collection` (#24) — independent of that phase's content, but built on top of it in the working tree. This PR's diff will shrink to just the Phase 3 delta once earlier phases merge.

## Test plan
- [x] `pytest computation_ir_tests/ toolchain_phase1_tests/ toolchain_phase2_tests/` — 293 passed (20 new: differential, Rust-parity, optimizer-regression, surface-validation, and CLI-level tests for `assert`/`assert_eq` and the new `reason test` execution/reporting)
- [x] Full Python suite (`pytest -q`) — 2305 passed (1 pre-existing, unrelated environment failure: missing VS Code extension `node_modules`)
- [x] `cargo test --manifest-path ReasonRuntime/Cargo.toml --workspace` — all green
- [x] `cargo clippy -p reasonscript-computation-ir -p reasonscript-computation-runtime-cli` — no new warnings
- [x] Manual Python↔Rust parity smoke test for `assert`/`assert_eq` pass/fail cases, including one chained through `string.concat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)