### PR TITLE
Allow controlled recursion, bounded by max_call_depth (Phase 4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux desktop dependencies
         run: |
@@ -26,6 +29,9 @@ jobs:
             pkg-config
       - run: python3 -m pip install --upgrade pip
       - run: python3 -m pip install -r requirements-dev.txt
+      - name: Install VS Code extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
       - name: Fetch Rust dependencies
         run: |
           for manifest in */Cargo.toml; do

--- a/ReasonRuntime/crates/computation-ir/src/lib.rs
+++ b/ReasonRuntime/crates/computation-ir/src/lib.rs
@@ -18,4 +18,4 @@ pub mod vm;
 pub use ir::{decode, Program, SCHEMA};
 pub use reasonscript_tensor_core::{NumericMode, TensorPolicy};
 pub use value::{from_json, to_json, Value};
-pub use vm::{RuntimeError, Vm};
+pub use vm::{RuntimeError, Vm, DEFAULT_MAX_CALL_DEPTH, DEFAULT_MAX_LOOP_ITERATIONS};

--- a/ReasonRuntime/crates/computation-ir/src/vm.rs
+++ b/ReasonRuntime/crates/computation-ir/src/vm.rs
@@ -47,8 +47,11 @@ pub enum Outcome {
     NoValue,
 }
 
-const DEFAULT_MAX_LOOP_ITERATIONS: u64 = 10_000;
-const DEFAULT_MAX_CALL_DEPTH: u32 = 128;
+/// Compiler/runtime contract defaults (Phase 4, "制御された再帰"):
+/// overridable per request via `context.limits.max_call_depth` /
+/// `max_loop_iterations`, same mechanism as the Tensor policy limits.
+pub const DEFAULT_MAX_LOOP_ITERATIONS: u64 = 10_000;
+pub const DEFAULT_MAX_CALL_DEPTH: u32 = 128;
 
 pub struct Vm<'a> {
     functions: HashMap<&'a str, &'a Function>,
@@ -135,9 +138,17 @@ impl<'a> Vm<'a> {
             true,
             false,
             "RuntimeReal".to_owned(),
+            DEFAULT_MAX_CALL_DEPTH,
+            DEFAULT_MAX_LOOP_ITERATIONS,
         )
     }
 
+    /// `max_call_depth`/`max_loop_iterations`: Phase 4 ("制御された再帰")
+    /// exposes both as part of the compiler/runtime contract (the
+    /// `reasonscript-runtime-request/1.0` protocol's `context.limits`,
+    /// same mechanism the Tensor policy limits already use), rather than
+    /// only ever being the hardcoded `DEFAULT_MAX_CALL_DEPTH`/
+    /// `DEFAULT_MAX_LOOP_ITERATIONS` every caller silently got before.
     #[allow(clippy::too_many_arguments)]
     pub fn with_runtime_context(
         program: &'a Program,
@@ -148,6 +159,8 @@ impl<'a> Vm<'a> {
         filesystem_write: bool,
         trace_enabled: bool,
         backend: String,
+        max_call_depth: u32,
+        max_loop_iterations: u64,
     ) -> Self {
         let functions = program
             .functions
@@ -163,8 +176,8 @@ impl<'a> Vm<'a> {
         );
         Vm {
             functions,
-            max_loop_iterations: DEFAULT_MAX_LOOP_ITERATIONS,
-            max_call_depth: DEFAULT_MAX_CALL_DEPTH,
+            max_loop_iterations,
+            max_call_depth,
             tensors: RefCell::new(tensors),
             reason_objects: RefCell::new(HashMap::new()),
             reasoning_bindings: program
@@ -1445,6 +1458,43 @@ mod tests {
         vm.run_calculations(&program)
     }
 
+    /// Like `run`, but executes on a thread with an explicit, large
+    /// stack, and returns JSON instead of `Value` -- needed only for the
+    /// deep-recursion tests below. `Value` holds `Rc`, which isn't
+    /// `Send`, so results can't cross a `thread::spawn`/`.join()`
+    /// boundary directly; converting to `serde_json::Value` (fully
+    /// owned, no `Rc`) inside the worker thread before it returns
+    /// sidesteps that.
+    ///
+    /// This exists because `cargo test`'s own per-test thread stack is
+    /// markedly smaller than a real process's main thread (how
+    /// `reason-runtime-host` is actually invoked, where the OS default
+    /// already comfortably covers `max_call_depth`'s 128-level default)
+    /// -- without it, `unbounded_recursion_stops_at_max_call_depth_with_rt_call_003`
+    /// below stack-overflows and aborts the whole test binary before the
+    /// depth check ever fires, instead of exercising it. `runtime-cli`'s
+    /// `main` defends against the same underlying risk in production the
+    /// same way (see its `run_main` wrapper) -- the depth check is only
+    /// the *actual*, deterministic limit if the executing thread has
+    /// enough native stack to reach it without overflowing first.
+    fn run_json_on_large_stack(source: &str) -> Result<serde_json::Value, String> {
+        const STACK_SIZE: usize = 64 * 1024 * 1024;
+        let source = source.to_string();
+        std::thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(move || -> Result<serde_json::Value, String> {
+                let results = run(&source).map_err(|error| error.code)?;
+                let mut map = serde_json::Map::new();
+                for (name, value) in results {
+                    map.insert(name, to_json(&value));
+                }
+                Ok(serde_json::Value::Object(map))
+            })
+            .expect("failed to spawn test worker thread")
+            .join()
+            .expect("test worker thread panicked")
+    }
+
     #[test]
     fn integer_division_by_int_is_float() {
         let ir = r#"{
@@ -1970,5 +2020,132 @@ mod tests {
         }"#;
         let results = run(ir).expect("no runtime error");
         assert_eq!(results, vec![("Answer".to_string(), Value::Int(5))]);
+    }
+
+    #[test]
+    fn direct_self_recursion_computes_correctly() {
+        // Phase 4 ("制御された再帰"): a function calling itself is no
+        // longer rejected at the language-surface level (FN-007 removed)
+        // -- this proves the VM's own call-depth machinery (already
+        // present for ordinary nested calls) handles a self-referential
+        // `call_function` correctly, independent of the Python lowering
+        // pipeline.
+        let ir = r#"{
+            "schema": "reason-computation-ir/0.2",
+            "calculations": ["Answer"],
+            "functions": [
+                {
+                    "id": "fn.Factorial",
+                    "parameters": ["n"],
+                    "entry_block": "b1",
+                    "blocks": [
+                        {
+                            "id": "b1",
+                            "instructions": [],
+                            "terminator": {
+                                "kind": "branch",
+                                "condition": {
+                                    "op": "comparison", "operator": "LessThanOrEqual",
+                                    "left": {"op": "local", "name": "n"},
+                                    "right": {"op": "const", "kind": "int", "value": 1}
+                                },
+                                "then": "b_base",
+                                "else": "b_recurse"
+                            }
+                        },
+                        {
+                            "id": "b_base",
+                            "instructions": [],
+                            "terminator": {"kind": "return", "value": {"op": "const", "kind": "int", "value": 1}}
+                        },
+                        {
+                            "id": "b_recurse",
+                            "instructions": [],
+                            "terminator": {
+                                "kind": "return",
+                                "value": {
+                                    "op": "binary", "operator": "Multiply",
+                                    "left": {"op": "local", "name": "n"},
+                                    "right": {
+                                        "op": "call_function", "name": "Factorial",
+                                        "arguments": [{
+                                            "op": "binary", "operator": "Subtract",
+                                            "left": {"op": "local", "name": "n"},
+                                            "right": {"op": "const", "kind": "int", "value": 1}
+                                        }]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "Answer",
+                    "parameters": [],
+                    "entry_block": "b1",
+                    "blocks": [{
+                        "id": "b1",
+                        "instructions": [],
+                        "terminator": {
+                            "kind": "result",
+                            "value": {
+                                "op": "call_function", "name": "Factorial",
+                                "arguments": [{"op": "const", "kind": "int", "value": 5}]
+                            }
+                        }
+                    }]
+                }
+            ]
+        }"#;
+        let result = run_json_on_large_stack(ir).expect("no runtime error");
+        assert_eq!(result["Answer"], serde_json::json!(120));
+    }
+
+    #[test]
+    fn unbounded_recursion_stops_at_max_call_depth_with_rt_call_003() {
+        let ir = r#"{
+            "schema": "reason-computation-ir/0.2",
+            "calculations": ["Answer"],
+            "functions": [
+                {
+                    "id": "fn.Loop",
+                    "parameters": ["n"],
+                    "entry_block": "b1",
+                    "blocks": [{
+                        "id": "b1",
+                        "instructions": [],
+                        "terminator": {
+                            "kind": "return",
+                            "value": {
+                                "op": "call_function", "name": "Loop",
+                                "arguments": [{
+                                    "op": "binary", "operator": "Add",
+                                    "left": {"op": "local", "name": "n"},
+                                    "right": {"op": "const", "kind": "int", "value": 1}
+                                }]
+                            }
+                        }
+                    }]
+                },
+                {
+                    "id": "Answer",
+                    "parameters": [],
+                    "entry_block": "b1",
+                    "blocks": [{
+                        "id": "b1",
+                        "instructions": [],
+                        "terminator": {
+                            "kind": "result",
+                            "value": {
+                                "op": "call_function", "name": "Loop",
+                                "arguments": [{"op": "const", "kind": "int", "value": 0}]
+                            }
+                        }
+                    }]
+                }
+            ]
+        }"#;
+        let error_code = run_json_on_large_stack(ir).expect_err("must fail");
+        assert_eq!(error_code, "RT-CALL-003");
     }
 }

--- a/ReasonRuntime/crates/runtime-cli/src/main.rs
+++ b/ReasonRuntime/crates/runtime-cli/src/main.rs
@@ -21,13 +21,37 @@ use std::fs;
 use std::io::{self, Read};
 use std::process::ExitCode;
 
-use reasonscript_computation_ir::{decode, to_json, NumericMode, TensorPolicy, Vm};
+use reasonscript_computation_ir::{
+    decode, to_json, NumericMode, TensorPolicy, Vm, DEFAULT_MAX_CALL_DEPTH,
+    DEFAULT_MAX_LOOP_ITERATIONS,
+};
 
 const REQUEST_SCHEMA: &str = "reasonscript-runtime-request/1.0";
 const RESULT_SCHEMA: &str = "reasonscript-runtime-result/1.0";
 const HOST_PROFILE: &str = "reasonscript-runtime-host/1.0";
 
 fn main() -> ExitCode {
+    // Phase 4 ("制御された再帰"): `Vm::call_function` recurses natively
+    // (`call_function` -> `run_function` -> `eval_expr` -> ...) rather
+    // than trampolining, so `max_call_depth`'s check is only the actual,
+    // deterministic limit on recursion if the executing thread has
+    // enough native stack to reach that depth without overflowing (a
+    // hard process abort, not the stable `RT-CALL-003` diagnostic the
+    // check is meant to produce) first. A thread's default stack size
+    // varies by platform and caller -- run on an explicitly-sized one so
+    // that stays true regardless of what stack size the calling context
+    // happens to provide, rather than depending on the OS process
+    // default being generous enough.
+    const STACK_SIZE: usize = 64 * 1024 * 1024;
+    std::thread::Builder::new()
+        .stack_size(STACK_SIZE)
+        .spawn(run_main)
+        .expect("failed to spawn runtime-host worker thread")
+        .join()
+        .expect("runtime-host worker thread panicked")
+}
+
+fn run_main() -> ExitCode {
     let path = env::args().nth(1);
     if path.as_deref() == Some("verify-native") {
         println!(
@@ -188,6 +212,13 @@ fn run_request(request: &serde_json::Value) -> ExitCode {
         "max_saved_tensor_bytes",
         tensor_policy.max_saved_tensor_bytes,
     );
+    let max_call_depth =
+        limit(limits, "max_call_depth", DEFAULT_MAX_CALL_DEPTH as usize) as u32;
+    let max_loop_iterations = limit(
+        limits,
+        "max_loop_iterations",
+        DEFAULT_MAX_LOOP_ITERATIONS as usize,
+    ) as u64;
     let capabilities = context
         .get("capabilities")
         .and_then(serde_json::Value::as_object)
@@ -228,6 +259,8 @@ fn run_request(request: &serde_json::Value) -> ExitCode {
         filesystem_write,
         trace_enabled,
         backend,
+        max_call_depth,
+        max_loop_iterations,
     );
     match vm.run_calculations(&program) {
         Ok(calculations) => {

--- a/computation_ir_tests/test_computation_ir_recursion.py
+++ b/computation_ir_tests/test_computation_ir_recursion.py
@@ -1,0 +1,362 @@
+"""Phase 4 ("制御された再帰"): direct and mutual recursion are allowed,
+bounded by a stable, deterministic `max_call_depth` -- `FN-007`'s
+unconditional rejection is gone, and every evaluator already had the
+call-depth bookkeeping (`RT-CALL-003`) needed to make this safe, since it
+already applied to ordinary (non-recursive) nested calls.
+
+Same differential/parity pattern as every other `computation_ir_tests`
+suite: lower once, run through the AST oracle, the Python IR interpreter,
+and the Rust CLI, and assert they agree exactly. Rust comparisons are
+skipped (not failed) if the binary isn't built.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from frontend.computation_ir import interpret_program, lower_program, validate_program
+from frontend.computation_ir.differential import assert_same_outcome
+from frontend.computation_ir.optimizer import classify_pure_functions, optimize_program
+from frontend.computation_ir.rust_bridge import find_binary, run_ir
+from frontend.integrated_computation_runtime import IntegratedRuntimeError, LoopLimitError
+from frontend.language_surface import parse
+
+_BINARY = find_binary()
+
+
+def _lower(source: str):
+    return lower_program(parse(source))
+
+
+def _python_outcome(source: str):
+    ir = optimize_program(_lower(source))
+    try:
+        result = interpret_program(ir)
+    except (IntegratedRuntimeError, LoopLimitError) as error:
+        return None, getattr(error, "code", None)
+    return dict(result.calculation_results), None
+
+
+def _rust_outcome(source: str):
+    ir = optimize_program(_lower(source))
+    outcome = run_ir(ir, binary=_BINARY)
+    if outcome.ok:
+        return outcome.calculation_results, None
+    return None, outcome.error_code
+
+
+class RecursionParityMixin:
+    def assert_parity(self, source: str):
+        ir = optimize_program(_lower(source))
+        self.assertEqual(validate_program(ir), [])
+        python_results, python_error = _python_outcome(source)
+        if _BINARY is not None:
+            rust_results, rust_error = _rust_outcome(source)
+            self.assertEqual(python_error, rust_error, f"error code mismatch for:\n{source}")
+            if python_error is None:
+                self.assertEqual(python_results, rust_results, f"result mismatch for:\n{source}")
+        return python_results, python_error
+
+
+class DirectRecursionTests(RecursionParityMixin, unittest.TestCase):
+    def test_factorial_computes_correctly(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                fn Factorial(n: int) -> int {
+                    if n <= 1 {
+                        return 1
+                    }
+                    return n * Factorial(n - 1)
+                }
+
+                calculation Answer {
+                    result = Factorial(5)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 120)
+
+    def test_fibonacci_branching_recursion_computes_correctly(self):
+        # Each call spawns two further recursive calls (not a single
+        # linear chain like Factorial), stressing multiple concurrently
+        # active frames of the same function at different depths.
+        results, error = self.assert_parity(
+            """
+            module M {
+                fn Fib(n: int) -> int {
+                    if n <= 1 {
+                        return n
+                    }
+                    return Fib(n - 1) + Fib(n - 2)
+                }
+
+                calculation Answer {
+                    result = Fib(10)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], 55)
+
+    def test_unbounded_recursion_stops_with_rt_call_003_on_both_backends(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                fn Loop(n: int) -> int {
+                    return Loop(n + 1)
+                }
+
+                calculation Answer {
+                    result = Loop(0)
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "RT-CALL-003")
+
+
+class MutualRecursionTests(RecursionParityMixin, unittest.TestCase):
+    def test_is_even_is_odd_computes_correctly(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                fn IsEven(n: int) -> bool {
+                    if n == 0 {
+                        return true
+                    }
+                    return IsOdd(n - 1)
+                }
+
+                fn IsOdd(n: int) -> bool {
+                    if n == 0 {
+                        return false
+                    }
+                    return IsEven(n - 1)
+                }
+
+                calculation Answer {
+                    result = IsEven(10)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], True)
+
+    def test_unbounded_mutual_recursion_stops_with_rt_call_003(self):
+        _, error = self.assert_parity(
+            """
+            module M {
+                fn PingForever(n: int) -> int {
+                    return PongForever(n + 1)
+                }
+
+                fn PongForever(n: int) -> int {
+                    return PingForever(n + 1)
+                }
+
+                calculation Answer {
+                    result = PingForever(0)
+                }
+            }
+            """
+        )
+        self.assertEqual(error, "RT-CALL-003")
+
+
+class RecursiveResourceLivenessTests(RecursionParityMixin, unittest.TestCase):
+    """A Tensor handle bound in a caller's frame before a deep recursive
+    call chain begins must still be correct once that chain fully
+    unwinds -- Tensor data lives in a separate `TensorStore`
+    (`collect_tensors`'s mark-and-sweep, not plain `Rc` ownership), so a
+    liveness bug specific to *stacked frames of the same function*
+    (rather than ordinary nested calls to different functions, which the
+    pre-existing test suite already covered) would show up as either a
+    crash or the caller's Tensor silently returning stale/wrong data.
+
+    RUO/ReasonObject resources have no such risk to test here: they're
+    plain `Rc`-owned values (see `collect_tensor_ids` in `vm.rs`, which
+    only ever walks `Value::Tensor`/`Array`/`Struct` -- ReasonObject
+    values are never part of that sweep), so standard Rust ownership
+    already guarantees they survive any call depth without a
+    recursion-specific mechanism to verify.
+    """
+
+    def test_caller_tensor_survives_a_five_level_recursive_call_chain(self):
+        results, error = self.assert_parity(
+            """
+            module M {
+                fn RecurseSum(t: Tensor, n: int) -> Tensor {
+                    if n <= 0 {
+                        return t
+                    }
+                    let step = tensor.create([1.0], "f64")
+                    let combined = tensor.add(t, step)
+                    return RecurseSum(combined, n - 1)
+                }
+
+                calculation Answer {
+                    let caller_tensor = tensor.create([5.0], "f64")
+                    let start = tensor.create([0.0], "f64")
+                    let recursed = RecurseSum(start, 5)
+                    let final_tensor = tensor.add(caller_tensor, recursed)
+                    result = tensor.to_array(final_tensor)
+                }
+            }
+            """
+        )
+        self.assertIsNone(error)
+        self.assertEqual(results["Answer"], [10.0])
+
+
+class SurfaceValidationTests(unittest.TestCase):
+    """FN-007 no longer rejects a function calling itself, directly or
+    mutually -- `parse()` (which runs full language-surface validation)
+    must succeed on both shapes."""
+
+    def test_direct_recursion_is_accepted(self):
+        parse(
+            """
+            module M {
+                fn Factorial(n: int) -> int {
+                    if n <= 1 {
+                        return 1
+                    }
+                    return n * Factorial(n - 1)
+                }
+
+                calculation Answer {
+                    result = Factorial(5)
+                }
+            }
+            """
+        )
+
+    def test_mutual_recursion_is_accepted(self):
+        parse(
+            """
+            module M {
+                fn IsEven(n: int) -> bool {
+                    if n == 0 {
+                        return true
+                    }
+                    return IsOdd(n - 1)
+                }
+
+                fn IsOdd(n: int) -> bool {
+                    if n == 0 {
+                        return false
+                    }
+                    return IsEven(n - 1)
+                }
+
+                calculation Answer {
+                    result = IsEven(10)
+                }
+            }
+            """
+        )
+
+
+class OptimizerRecursionTests(unittest.TestCase):
+    """The optimizer's fast-path scalar inlining already had to guard
+    against recursive functions (an inlining pass can't terminate against
+    a call graph with a cycle) before Phase 4 ever made recursion
+    reachable from real source -- this just confirms that guard still
+    correctly recognizes both direct and mutual recursion now that it
+    can actually be exercised end-to-end, instead of only having ever run
+    against non-recursive fixtures."""
+
+    def test_classify_pure_functions_marks_direct_recursion_as_recursive(self):
+        ir = _lower(
+            """
+            module M {
+                fn Factorial(n: int) -> int {
+                    if n <= 1 {
+                        return 1
+                    }
+                    return n * Factorial(n - 1)
+                }
+
+                calculation Answer {
+                    result = Factorial(5)
+                }
+            }
+            """
+        )
+        classifications = classify_pure_functions(ir)
+        self.assertTrue(classifications["M::Factorial"].recursive)
+        self.assertFalse(classifications["M::Factorial"].eligible_for_fast_path)
+
+    def test_classify_pure_functions_marks_mutual_recursion_as_recursive(self):
+        ir = _lower(
+            """
+            module M {
+                fn IsEven(n: int) -> bool {
+                    if n == 0 {
+                        return true
+                    }
+                    return IsOdd(n - 1)
+                }
+
+                fn IsOdd(n: int) -> bool {
+                    if n == 0 {
+                        return false
+                    }
+                    return IsEven(n - 1)
+                }
+
+                calculation Answer {
+                    result = IsEven(10)
+                }
+            }
+            """
+        )
+        classifications = classify_pure_functions(ir)
+        self.assertTrue(classifications["M::IsEven"].recursive)
+        self.assertTrue(classifications["M::IsOdd"].recursive)
+
+    def test_recursive_function_survives_optimize_program_without_hanging(self):
+        ir = _lower(
+            """
+            module M {
+                fn Factorial(n: int) -> int {
+                    if n <= 1 {
+                        return 1
+                    }
+                    return n * Factorial(n - 1)
+                }
+
+                calculation Answer {
+                    result = Factorial(5)
+                }
+            }
+            """
+        )
+        optimized = optimize_program(ir)
+        outcome = assert_same_outcome(
+            """
+            module M {
+                fn Factorial(n: int) -> int {
+                    if n <= 1 {
+                        return 1
+                    }
+                    return n * Factorial(n - 1)
+                }
+
+                calculation Answer {
+                    result = Factorial(5)
+                }
+            }
+            """
+        )
+        self.assertEqual(outcome.calculations["Answer"], 120)
+        del optimized
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/specs/function_semantic_integration_v1.md
+++ b/docs/specs/function_semantic_integration_v1.md
@@ -37,7 +37,15 @@ Validation coverage:
 - `FN-004`: non-void functions require a guaranteed terminal return.
 - `FN-005`: return expressions and call arguments must match declared types.
 - `FN-006`: duplicate parameter names are invalid.
-- `FN-007`: direct recursive calls are rejected for v1.0.
+- `FN-007` (retired): direct recursive calls were unconditionally rejected
+  through v1.0. Phase 4 of the modernization plan ("制御された再帰") lifted
+  this for both direct and mutual recursion -- every evaluator (the AST
+  oracle, the Python Computation IR interpreter, and the Rust VM) already
+  bounded call depth with a stable `RT-CALL-003` diagnostic for ordinary
+  nested calls, so the same bound now governs recursive calls too. The
+  default `max_call_depth` (128) is part of the compiler/runtime contract
+  via `reason.toml`'s `[runtime] max_call_depth`, the same way `backend`
+  already is.
 - `FN-008`: nested calls preserve inner-to-outer evaluation order and unique
   transition identities.
 - `FN-009`: multiline typed parameter lists parse equivalently to single-line

--- a/frontend/language_surface/validation.py
+++ b/frontend/language_surface/validation.py
@@ -287,7 +287,6 @@ class SurfaceValidationError(ValueError):
 
 
 _CURRENT_NAMESPACE: ModuleNamespace | None = None
-_CURRENT_FUNCTION: str | None = None
 RUNTIME_RESULT_TYPES = {
     "SearchResult",
     "SimulationResult",
@@ -840,7 +839,6 @@ def _calculation_expression_identifiers(expression: ExpressionNode | Any) -> set
 
 
 def _validate_function(node: FunctionDeclarationNode, symbols: dict[str, Any]) -> None:
-    global _CURRENT_FUNCTION
     _validate_ast_node(node)
     if node.return_type is not None:
         _resolve_type(node.return_type, symbols)
@@ -851,19 +849,14 @@ def _validate_function(node: FunctionDeclarationNode, symbols: dict[str, Any]) -
         )
         for parameter in node.parameters
     }
-    previous_function = _CURRENT_FUNCTION
-    _CURRENT_FUNCTION = node.name
-    try:
-        _validate_function_statements(
-            node.body,
-            symbols=symbols,
-            bindings=bindings,
-            allow_terminal_return=True,
-            loop_depth=0,
-            return_type=node.return_type,
-        )
-    finally:
-        _CURRENT_FUNCTION = previous_function
+    _validate_function_statements(
+        node.body,
+        symbols=symbols,
+        bindings=bindings,
+        allow_terminal_return=True,
+        loop_depth=0,
+        return_type=node.return_type,
+    )
     _validate_function_control_flow(node.body)
     if not _statement_list_terminates_with_return(node.body):
         raise SurfaceValidationError("FN-010 FCF-001 Not all execution paths return")
@@ -2350,8 +2343,6 @@ def _expression_type(
             )
             return null_type
         if isinstance(value.callee, IdentifierNode):
-            if value.callee.name == _CURRENT_FUNCTION:
-                raise SurfaceValidationError("FN-007 recursive function calls are rejected")
             function = symbols.get(value.callee.name)
             if isinstance(function, FunctionDeclarationNode):
                 if len(value.arguments) != len(function.parameters):

--- a/toolchain/manifest.py
+++ b/toolchain/manifest.py
@@ -24,6 +24,12 @@ class Manifest:
     language_core: str
     platform: str
     backend: str
+    # `None` means "use the Rust VM's own built-in default"
+    # (`DEFAULT_MAX_CALL_DEPTH`) -- the default value itself is not
+    # duplicated here, only whether the project overrides it (Phase 4,
+    # "制御された再帰": max_call_depth as part of the compiler/runtime
+    # contract, the same way `backend` already is).
+    max_call_depth: int | None = None
     dependencies: dict[str, object] = field(default_factory=dict)
 
     @staticmethod
@@ -38,6 +44,7 @@ class Manifest:
             compiler = data.get("compiler", {})
             runtime = data.get("runtime", {})
             backend = runtime.get("backend", "RuntimeReal")
+            max_call_depth = runtime.get("max_call_depth")
         except KeyError as e:
             raise ManifestError(f"reason.toml missing field: {e}") from e
         if backend not in SUPPORTED_BACKENDS:
@@ -45,11 +52,18 @@ class Manifest:
                 f"Unknown runtime backend '{backend}'. "
                 f"Supported: {', '.join(sorted(SUPPORTED_BACKENDS))}"
             )
+        if max_call_depth is not None and (
+            isinstance(max_call_depth, bool)
+            or not isinstance(max_call_depth, int)
+            or max_call_depth < 1
+        ):
+            raise ManifestError("runtime.max_call_depth must be a positive integer")
         return Manifest(
             name=package["name"],
             version=package["version"],
             language_core=compiler.get("language_core", "0.7"),
             platform=compiler.get("platform", "0.2"),
             backend=backend,
+            max_call_depth=max_call_depth,
             dependencies=dict(data.get("dependencies", {})),
         )

--- a/toolchain/run_cmd.py
+++ b/toolchain/run_cmd.py
@@ -134,6 +134,7 @@ def _run_package(
             filesystem_write,
             backend=manifest.backend,
             include_trace=include_trace,
+            max_call_depth=manifest.max_call_depth,
         )
     except RustDispatchError as error:
         print(json.dumps({"status": "failure", "diagnostics": [error.to_diagnostic()]}, indent=2))

--- a/toolchain/runner_cmd.py
+++ b/toolchain/runner_cmd.py
@@ -169,6 +169,7 @@ def _collect_package(
                 filesystem_read,
                 filesystem_write,
                 backend=manifest.backend,
+                max_call_depth=manifest.max_call_depth,
             )
         except RustDispatchError as error:
             if error.reason in _INFRASTRUCTURE_REASONS:

--- a/toolchain/runtime_dispatch.py
+++ b/toolchain/runtime_dispatch.py
@@ -37,6 +37,7 @@ def execute_rust_program(
     *,
     backend: str = "RuntimeReal",
     include_trace: bool = False,
+    max_call_depth: int | None = None,
 ) -> dict[str, Any]:
     from frontend.computation_ir import LoweringError, lower_program
     from frontend.computation_ir.optimizer import optimize_program
@@ -56,6 +57,7 @@ def execute_rust_program(
         filesystem_write,
         backend=backend,
         include_trace=include_trace,
+        max_call_depth=max_call_depth,
     )
 
 
@@ -67,6 +69,7 @@ def execute_rust_ir(
     *,
     backend: str = "RuntimeReal",
     include_trace: bool = False,
+    max_call_depth: int | None = None,
 ) -> dict[str, Any]:
     from frontend.computation_ir.rust_bridge import find_binary, run_ir
 
@@ -88,6 +91,12 @@ def execute_rust_ir(
     # turn an otherwise executable calculation into a runtime failure.
     trace_unsupported = rust_trace_unsupported_operations(ir_document) if include_trace else ()
     trace_enabled = include_trace and not trace_unsupported
+    # Phase 4 ("制御された再帰"): `None` leaves `max_call_depth` out of the
+    # request entirely, so the Rust host falls back to its own
+    # DEFAULT_MAX_CALL_DEPTH -- the default value itself isn't duplicated
+    # here, only whether the caller (ultimately, `reason.toml`'s
+    # `[runtime] max_call_depth`) overrides it.
+    limits = {"max_call_depth": max_call_depth} if max_call_depth is not None else {}
     try:
         outcome = run_ir(
             ir_document,
@@ -97,6 +106,7 @@ def execute_rust_ir(
             filesystem_write=filesystem_write,
             backend=backend,
             trace_enabled=trace_enabled,
+            limits=limits,
         )
     except (OSError, ValueError) as error:
         raise RustDispatchError(

--- a/toolchain_phase1_tests/test_toolchain_conformance.py
+++ b/toolchain_phase1_tests/test_toolchain_conformance.py
@@ -86,6 +86,50 @@ platform = "0.2"
 backend = "RuntimeReal"
 """
 
+_RECURSIVE_RSN = """\
+package depthtest
+module main {
+    fn CountUp(n: int) -> int {
+        if n >= 10 {
+            return n
+        }
+        return CountUp(n + 1)
+    }
+
+    calculation Answer {
+        result = CountUp(0)
+    }
+}
+"""
+
+
+def _recursive_reason_toml(max_call_depth: int | None) -> str:
+    lines = [
+        "[package]",
+        'name = "depthtest"',
+        'version = "0.1.0"',
+        "",
+        "[compiler]",
+        'language_core = "0.7"',
+        'platform = "0.2"',
+        "",
+        "[runtime]",
+        'backend = "RuntimeReal"',
+    ]
+    if max_call_depth is not None:
+        lines.append(f"max_call_depth = {max_call_depth}")
+    return "\n".join(lines) + "\n"
+
+
+def _setup_recursive_project(root: Path, *, max_call_depth: int | None) -> None:
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "target" / "ast").mkdir(parents=True, exist_ok=True)
+    (root / "target" / "ir").mkdir(parents=True, exist_ok=True)
+    (root / "target" / "metadata").mkdir(parents=True, exist_ok=True)
+    (root / "target" / "runtime").mkdir(parents=True, exist_ok=True)
+    (root / "reason.toml").write_text(_recursive_reason_toml(max_call_depth), encoding="utf-8")
+    (root / "src" / "main.rsn").write_text(_RECURSIVE_RSN, encoding="utf-8")
+
 
 def _collect_only(
     project_root: Path, *, compile_only: bool = False
@@ -503,6 +547,60 @@ class TC1010DeterministicRebuild(unittest.TestCase):
         for f in sorted((self.tmp / "target" / "ir").glob("*.json")):
             result[f.name] = json.loads(f.read_text())
         return result
+
+
+class TC1011MaxCallDepthContract(unittest.TestCase):
+    """TC1-011 (Phase 4, "制御された再帰"): `reason.toml`'s
+    `[runtime] max_call_depth` is a genuine part of the compiler/runtime
+    contract end to end -- not just a `Manifest`-parsing detail -- the
+    same way `backend` already is (TC1-007)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_max_call_depth_accepts_a_positive_integer(self):
+        (self.tmp / "reason.toml").write_text(_recursive_reason_toml(5), encoding="utf-8")
+        manifest = Manifest.load(self.tmp)
+        self.assertEqual(manifest.max_call_depth, 5)
+
+    def test_max_call_depth_defaults_to_none_when_unset(self):
+        (self.tmp / "reason.toml").write_text(_recursive_reason_toml(None), encoding="utf-8")
+        manifest = Manifest.load(self.tmp)
+        self.assertIsNone(manifest.max_call_depth)
+
+    def test_non_positive_max_call_depth_is_rejected(self):
+        (self.tmp / "reason.toml").write_text(
+            _recursive_reason_toml(None).rstrip("\n") + "\nmax_call_depth = 0\n",
+            encoding="utf-8",
+        )
+        with self.assertRaises(ManifestError):
+            Manifest.load(self.tmp)
+
+    def test_reason_run_stops_at_a_configured_max_call_depth(self):
+        # CountUp needs 10 recursive calls to finish; a configured limit
+        # of 5 must stop it with RT-CALL-003 instead of running to
+        # completion.
+        _setup_recursive_project(self.tmp, max_call_depth=5)
+        build_run(self.tmp)
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            rc = run_run(self.tmp)
+        self.assertEqual(rc, 2)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["diagnostics"][0]["code"], "RT-CALL-003")
+
+    def test_reason_run_succeeds_without_a_configured_limit(self):
+        _setup_recursive_project(self.tmp, max_call_depth=None)
+        build_run(self.tmp)
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            rc = run_run(self.tmp)
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["runtime_result"]["result"], 10)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes `FN-007`'s unconditional rejection of a function calling itself. Every evaluator (the AST oracle, the Python Computation IR interpreter, and the Rust VM) already bounded call depth with a stable `RT-CALL-003` diagnostic for ordinary nested calls, so the same bound now governs direct **and mutual** recursion too — zero new IR surface needed, recursion is just an ordinary `call_function` whose target happens to be (transitively) itself.
- **Found and fixed a real crash risk**: `call_function` recurses natively in the Rust VM, so `max_call_depth`'s check is only the actual, deterministic limit if the executing thread has enough native stack to reach that depth without overflowing first (a hard process abort instead of `RT-CALL-003`). `reason-runtime-host`'s `main` now always runs on an explicitly large stack rather than relying on the OS default being generous enough — discovered via `cargo test`'s own, markedly smaller per-test-thread stack overflowing at the default 128-deep limit (the production binary's OS-provided main-thread stack was already safe at that depth, but depending on caller-provided stack size was the real bug worth removing).
- Exposes `max_call_depth` as part of the compiler/runtime contract via `reason.toml`'s `[runtime] max_call_depth`, the same way `backend` already is — threaded through `Manifest`, `runtime_dispatch.execute_rust_program`/`execute_rust_ir`, and the Rust request protocol's `context.limits` (previously Tensor-policy-only).

## Test plan
- [x] `pytest computation_ir_tests/ toolchain_phase1_tests/ toolchain_phase2_tests/` — 309 passed (16 new: differential, Rust-parity, surface-validation, optimizer-regression, and CLI/manifest-contract tests, including a Tensor-liveness check across a five-level recursive call chain)
- [x] Full Python suite (`pytest -q`) — 2321 passed (1 pre-existing, unrelated environment failure: missing VS Code extension `node_modules`)
- [x] `cargo test --manifest-path ReasonRuntime/Cargo.toml --workspace` — all green, including 2 new inline VM tests (factorial recursion, unbounded-recursion → `RT-CALL-003`)
- [x] `cargo clippy -p reasonscript-computation-ir -p reasonscript-computation-runtime-cli` — no new warnings
- [x] Manual end-to-end smoke test: `reason.toml`'s `max_call_depth` correctly stops/permits a configurable-depth recursive program via `reason run`

**Base note:** stacked on `claude/reasonscript-phase3-executable-tests` (#25) — independent of that phase's content, but built on top of it in the working tree. This PR's diff will shrink to just the Phase 4 delta once earlier phases merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)