### PR TITLE
[UERA-1] Add deterministic cluster execution planning

### DIFF
--- a/ClusterRuntime/src/lib.rs
+++ b/ClusterRuntime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod planner;
 pub mod runtime;
 pub mod state;
 pub mod test_model;
+pub mod uera;
 pub mod worker;
 
 pub use config::{ClusterConfig, ExecutionConfig, Limits, NodeConfig};

--- a/ClusterRuntime/src/main.rs
+++ b/ClusterRuntime/src/main.rs
@@ -16,7 +16,9 @@ use reasonscript_cluster_runtime::{
     evaluator::compare,
     planner::build_cluster_plan,
     runtime::{run_cluster, RunOptions},
-    test_model, worker,
+    test_model,
+    uera::build_uera_plan,
+    worker,
     worker::RuntimeContext,
     ReasonTask,
 };
@@ -35,6 +37,43 @@ fn main() {
 fn run() -> Result<i32, String> {
     let args: Vec<String> = env::args().skip(1).collect();
     let command = args.first().map(String::as_str).unwrap_or("");
+    if command == "uera-plan" {
+        let envelope = read_stdin_json()?;
+        let execution_plan = envelope
+            .get("execution_plan")
+            .ok_or("CRR-UER-004: execution_plan is required")?;
+        let operation_ids: Vec<String> = serde_json::from_value(
+            envelope
+                .get("operation_ids")
+                .cloned()
+                .ok_or("CRR-UER-005: operation_ids are required")?,
+        )
+        .map_err(|error| format!("CRR-UER-005: {error}"))?;
+        let workers: Vec<String> = serde_json::from_value(
+            envelope
+                .get("workers")
+                .cloned()
+                .ok_or("CRR-UER-001: workers are required")?,
+        )
+        .map_err(|error| format!("CRR-UER-001: {error}"))?;
+        let available_workers: Vec<String> = envelope
+            .get("available_workers")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| format!("CRR-UER-003: {error}"))?
+            .unwrap_or_else(|| workers.clone());
+        let policy_version = envelope["policy_version"].as_str().unwrap_or("UERA-0.1");
+        let plan = build_uera_plan(
+            execution_plan,
+            &operation_ids,
+            &workers,
+            &available_workers,
+            policy_version,
+        )?;
+        print_value(&serde_json::to_value(plan).map_err(|error| error.to_string())?)?;
+        return Ok(0);
+    }
     if command == "verify-native" {
         print_value(
             &serde_json::json!({"ok":true,"profile":"reasonscript-cluster-runtime/0.2","unsafe_blocks":0}),

--- a/ClusterRuntime/src/uera.rs
+++ b/ClusterRuntime/src/uera.rs
@@ -1,0 +1,88 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::canonical::checksum;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct UeraPartition {
+    pub partition_index: usize,
+    pub operation_id: String,
+    pub partition_id: String,
+    pub preferred_worker: String,
+    pub assigned_worker: String,
+    pub fallback_used: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct UeraPlan {
+    pub schema_version: String,
+    pub policy_version: String,
+    pub source_plan_hash: String,
+    pub partitions: Vec<UeraPartition>,
+    pub reduction_order: Vec<String>,
+}
+
+/// Builds deterministic orchestration metadata without changing execution.
+pub fn build_uera_plan(
+    execution_plan: &Value,
+    operation_ids: &[String],
+    worker_ids: &[String],
+    available_worker_ids: &[String],
+    policy_version: &str,
+) -> Result<UeraPlan, String> {
+    let workers: Vec<_> = worker_ids
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    if workers.is_empty() {
+        return Err("CRR-UER-001: no cluster workers configured".into());
+    }
+    let available: BTreeSet<_> = available_worker_ids.iter().cloned().collect();
+    if available.is_empty() {
+        return Err("CRR-UER-002: no cluster workers available".into());
+    }
+    if !available.iter().all(|worker| workers.contains(worker)) {
+        return Err("CRR-UER-003: available worker is not configured".into());
+    }
+
+    let source_plan_hash = checksum(execution_plan).map_err(|error| error.to_string())?;
+    let mut partitions = Vec::with_capacity(operation_ids.len());
+    for (partition_index, operation_id) in operation_ids.iter().enumerate() {
+        let preferred_worker = workers[partition_index % workers.len()].clone();
+        let assigned_worker = (0..workers.len())
+            .map(|offset| &workers[(partition_index + offset) % workers.len()])
+            .find(|worker| available.contains(*worker))
+            .cloned()
+            .ok_or("CRR-UER-002: no cluster workers available")?;
+        let partition_id = checksum(&json!({
+            "execution_plan": execution_plan,
+            "operation_id": operation_id,
+            "partition_index": partition_index,
+            "policy_version": policy_version,
+        }))
+        .map_err(|error| error.to_string())?;
+        partitions.push(UeraPartition {
+            partition_index,
+            operation_id: operation_id.clone(),
+            partition_id,
+            fallback_used: assigned_worker != preferred_worker,
+            preferred_worker,
+            assigned_worker,
+        });
+    }
+    let reduction_order = partitions
+        .iter()
+        .map(|partition| partition.partition_id.clone())
+        .collect();
+    Ok(UeraPlan {
+        schema_version: "reasonscript-cluster-uera-plan/0.1".into(),
+        policy_version: policy_version.into(),
+        source_plan_hash,
+        partitions,
+        reduction_order,
+    })
+}

--- a/ClusterRuntime/tests/cluster_runtime.rs
+++ b/ClusterRuntime/tests/cluster_runtime.rs
@@ -8,6 +8,7 @@ use reasonscript_cluster_runtime::{
     runtime::{run_cluster, RunOptions},
     state::merge,
     test_model,
+    uera::build_uera_plan,
 };
 use serde_json::json;
 
@@ -89,6 +90,30 @@ fn state_merge_policies_are_deterministic() {
         json!([1, 2, 3])
     );
     assert!(merge(&json!({}), &json!({}), "custom_validated").is_err());
+}
+
+#[test]
+fn uera_plan_is_byte_identical_and_uses_canonical_fallback() {
+    let execution_plan = json!({"operations":["a","b","c"]});
+    let workers = vec!["worker-2".into(), "worker-0".into(), "worker-1".into()];
+    let available = vec!["worker-2".into(), "worker-0".into()];
+    let plans: Vec<_> = (0..3)
+        .map(|_| {
+            build_uera_plan(
+                &execution_plan,
+                &["a".into(), "b".into(), "c".into()],
+                &workers,
+                &available,
+                "UERA-0.1",
+            )
+            .unwrap()
+        })
+        .collect();
+    assert_eq!(plans[0], plans[1]);
+    assert_eq!(plans[1], plans[2]);
+    assert_eq!(plans[0].partitions[1].preferred_worker, "worker-1");
+    assert_eq!(plans[0].partitions[1].assigned_worker, "worker-2");
+    assert!(plans[0].partitions[1].fallback_used);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add deterministic UERA partition planning to ClusterRuntime
- expose it through `reason-cluster uera-plan`
- retain the current native-runtime verification command unchanged
- add deterministic fallback coverage

## Validation
- `cargo fmt --manifest-path ClusterRuntime/Cargo.toml --check`
- `cargo test --manifest-path ClusterRuntime/Cargo.toml` (11 passed)
- manual `reason-cluster uera-plan` invocation

This ports the low-risk orchestration layer from draft PR #21 without restoring retired runtime packages.